### PR TITLE
Add System.Memory

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -23,7 +23,7 @@
     "version": "4.5.0"
   },
   "System.Numerics.Vectors": {
-    "listed": true,
+    "listed": false,
     "version": "4.4.0"
   },
   "System.Runtime.CompilerServices.Unsafe": {

--- a/registry.json
+++ b/registry.json
@@ -14,6 +14,10 @@
     "listed": true,
     "version": "2.1.0"
   },
+  "System.Memory": {
+    "listed": true,
+    "version": "4.5.0"
+  },
   "System.Runtime.CompilerServices.Unsafe": {
     "listed": true,
     "version": "4.4.0"

--- a/registry.json
+++ b/registry.json
@@ -14,9 +14,17 @@
     "listed": true,
     "version": "2.1.0"
   },
+  "System.Buffers": {
+    "listed": true,
+    "version": "4.4.0"
+  },
   "System.Memory": {
     "listed": true,
     "version": "4.5.0"
+  },
+  "System.Numerics.Vectors": {
+    "listed": true,
+    "version": "4.4.0"
   },
   "System.Runtime.CompilerServices.Unsafe": {
     "listed": true,


### PR DESCRIPTION
Added System.Memory to the registry so that `Span<T>` and friends can be used without needing to bundle the assemblies with projects directly.