### PR TITLE
Add Sharpcompress (0.24.0)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -26,6 +26,10 @@
     "listed": true,
     "version": "2.1.0"
   },
+  "Sharpcompress": {
+    "listed": true,
+    "version": "0.24.0"
+  },
   "System.Buffers": {
     "listed": true,
     "version": "4.4.0"
@@ -41,6 +45,10 @@
   "System.Runtime.CompilerServices.Unsafe": {
     "listed": true,
     "version": "4.4.0"
+  },
+  "System.Text.Encoding.CodePages": {
+    "listed": false,
+    "version": "4.5.0"
   },
   "System.Threading.Tasks.Extensions": {
     "listed": false,


### PR DESCRIPTION
Adding Sharpcompress, which is general compression/decompression library fully in managed C#.
Useful for compressing data to send over the network for example.
I also added an entry for System.Text.Encoding.CodePages 4.5.0 which is a dependency.