### PR TITLE
Add K4os.Compression.LZ4

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -43,6 +43,10 @@
     "listed": true,
     "version": "2.0.0"
   },
+  "K4os.Compression.LZ4": {
+    "listed": true,
+    "version": "1.0.2" 
+  },
   "log4net": {
     "listed": true,
     "version": "2.0.11"


### PR DESCRIPTION
It's used by https://github.com/inc8877/OdinLZ4Extension.

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
