### PR TITLE
Add Ben.Demystifier

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -25,7 +25,7 @@
   },
   "Ben.Demystifier": {
     "listed": true,
-    "version": "0.0.43"
+    "version": "0.1.6"
   },
   "BugSplatDotNetStandard": {
     "listed": true,
@@ -393,9 +393,6 @@
   "System.Threading.Tasks.Extensions": {
     "listed": false,
     "version": "4.4.0"
-  },
-  "System.ValueTuple": {
-    "ignore": true
   },
   "Telnet": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -395,8 +395,7 @@
     "version": "4.4.0"
   },
   "System.ValueTuple": {
-    "listed": true,
-    "version": "4.4.0"
+    "ignore": true
   },
   "Telnet": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -23,6 +23,10 @@
     "listed": true,
     "version": "3.5.0"
   },
+  "Ben.Demystifier": {
+    "listed": true,
+    "version": "0.0.43"
+  },
   "BugSplatDotNetStandard": {
     "listed": true,
     "version": "1.0.0"
@@ -388,6 +392,10 @@
   },
   "System.Threading.Tasks.Extensions": {
     "listed": false,
+    "version": "4.4.0"
+  },
+  "System.ValueTuple": {
+    "listed": true,
     "version": "4.4.0"
   },
   "Telnet": {


### PR DESCRIPTION
Adds Ben.Demystifier package.
Also added System.ValueTuple as ignored, as the older versions of Ben.Demystifier depend on it.

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
