### PR TITLE
Add FastEnum

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -43,6 +43,10 @@
     "listed": true,
     "version": "0.0.2"
   },
+  "FastEnum": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "GeneticSharp": {
     "listed": true,
     "version": "2.0.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/FastEnum
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor **There is a UPM package [here](https://github.com/worldreaver/FastEnum), but it does not follow the latest changes.**
> - [x] The package has been tested with a Unity standalone player **As above.**
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above) **`System.Memory` and `System.Runtime.CompilerServices.Unsafe` are already available.**
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
