### PR TITLE
Extensible configuration

### DIFF
--- a/examples/docker/.gitignore
+++ b/examples/docker/.gitignore
@@ -1,0 +1,1 @@
+unity_packages/

--- a/examples/docker/Nuget.Config
+++ b/examples/docker/Nuget.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+services:
+    unitynuget:
+      build: ../..
+      environment:
+        - Registry:RootHttpUrl=http://localhost:5000/ # Server Url to build the absolute path to the package.
+        - Registry:UnityScope=org.custom # Packages prefix, default is "org.nuget" but it can be modified to be able to have several containers with different prefixes and to be able to add several scope registries.
+        - Registry:MinimumUnityVersion=2020.1 # Minimum version of Unity required to install packages, default is "2019.1".
+        - Registry:PackageNameNuGetPostFix= (Custom NuGet) # Suffix of the package title, useful in case of having several containers and several scope registries, default is " (NuGet)".
+        - Registry:RootPersistentFolder=custom_unity_packages # Path to the folder where the packages cache will be stored, default is "unity_packages".
+        - Registry:UpdateInterval=00:01:00 # Packages update interval, default is "00:10:00" (10 minutes).
+        - Registry:TargetFramework:Name=netstandard2.1 # Target framework: https://docs.microsoft.com/en-us/dotnet/standard/frameworks
+        - Registry:TargetFramework:DefineConstraint=NET_STANDARD_2_1 # Unity directive that should match with Target framework: https://docs.unity3d.com/Manual/PlatformDependentCompilation.html
+        - Logging:LogLevel:Default=Information
+      ports:
+        - 5000:80
+      volumes:
+        - ./unity_packages:/app/custom_unity_packages # Map the folder with the packages cache.
+        - ./registry.json:/app/registry.json # Override the package registry to be able to add or remove packages.
+        - ./NuGet.Config:/root/.nuget/NuGet/NuGet.Config # Override Nuget.config file with repository information. This file can be used to configure a custom NuGet repository: https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file

--- a/examples/docker/registry.json
+++ b/examples/docker/registry.json
@@ -1,0 +1,13 @@
+{
+  "CsvHelper": {
+    "listed": true,
+    "version": "13.0.0"
+  },
+  "FluentValidation": {
+    "listed": true,
+    "version": "10.0.4"
+  },
+  "Microsoft.CSharp": {
+    "ignore": true
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Only compatible with **`Unity 2019.1`** and potentially with newer version.
 
 ## Docker
 
-Example docker-compose.yml file:
+Example of a basic docker-compose.yml file:
 
 ```yaml
 services:
@@ -67,6 +67,8 @@ services:
     volumes:
       - ./unity_packages:/app/unity_packages
 ```
+
+There is a complete example in [examples/docker](examples/docker).
 
 ## FAQ
 

--- a/src/UnityNuGet.Server/Program.cs
+++ b/src/UnityNuGet.Server/Program.cs
@@ -16,13 +16,17 @@ namespace UnityNuGet.Server
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     //webBuilder.UseSetting("detailedErrors", "true");
-                    webBuilder.ConfigureServices(services =>
+                    webBuilder.ConfigureServices((context, services) =>
                     {
                         // Add the registry cache initializer
                         services.AddHostedService<RegistryCacheInitializer>();
                         // Add the registry cache updater
                         services.AddHostedService<RegistryCacheUpdater>();
                         services.AddSingleton<RegistryCacheSingleton>();
+
+                        services.AddOptions<RegistryOptions>()
+                            .Bind(context.Configuration.GetSection("Registry"))
+                            .ValidateDataAnnotations();
                     });
                     webBuilder.UseStartup<Startup>();
                 });

--- a/src/UnityNuGet.Server/Properties/launchSettings.json
+++ b/src/UnityNuGet.Server/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
     "UnityNuGetServer": {

--- a/src/UnityNuGet.Server/UnityNuGet.Server.csproj
+++ b/src/UnityNuGet.Server/UnityNuGet.Server.csproj
@@ -8,7 +8,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="5.0.0" />
+        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UnityNuGet.Server/appsettings.json
+++ b/src/UnityNuGet.Server/appsettings.json
@@ -1,4 +1,16 @@
 {
+  "Registry": {
+    "RootHttpUrl": "https://unitynuget-registry.azurewebsites.net/",
+    "UnityScope": "org.nuget",
+    "MinimumUnityVersion": "2019.1",
+    "PackageNameNuGetPostFix": " (NuGet)",
+    "RootPersistentFolder": "unity_packages",
+    "UpdateInterval": "00:10:00",
+    "TargetFramework": {
+      "Name": "netstandard2.0",
+      "DefineConstraint": "NET_STANDARD_2_0"
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Warning"

--- a/src/UnityNuGet.Tests/RegistryCacheTests.cs
+++ b/src/UnityNuGet.Tests/RegistryCacheTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -18,7 +19,7 @@ namespace UnityNuGet.Tests
         public async Task TestBuild()
         {
             var unityPackages = Path.Combine(Path.GetDirectoryName(typeof(RegistryCacheTests).Assembly.Location), "unity_packages");
-            var registryCache = new RegistryCache(unityPackages, "http://localhost");
+            var registryCache = new RegistryCache(unityPackages, new Uri("http://localhost/"), "org.nuget", "2019.1", " (NuGet)", new RegistryTargetFramework { Name = "netstandard2.0", DefineConstraint = "NET_STANDARD_2_0" }, new NuGetConsoleLogger());
 
             await registryCache.Build();
 

--- a/src/UnityNuGet.Tests/UnityNuGet.Tests.csproj
+++ b/src/UnityNuGet.Tests/UnityNuGet.Tests.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="nunit" Version="3.13.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+        <PackageReference Include="nunit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -27,6 +27,8 @@ namespace UnityNuGet
     public class RegistryCache
     {
         private static readonly Encoding Utf8EncodingNoBom = new UTF8Encoding(false, false);
+        private static readonly string NuGetFrameworkNetStandard20Id = "netstandard2.0";
+        private static readonly NuGetFramework NuGetFrameworkNetStandard20 = NuGetFramework.Parse(NuGetFrameworkNetStandard20Id);
         private readonly string _rootPersistentFolder;
         private readonly Uri _rootHttpUri;
         private readonly string _unityScope;
@@ -163,7 +165,17 @@ namespace UnityNuGet
 
                     if (resolvedDependencyGroup == null)
                     {
-                        _logger.LogWarning($"The package `{packageIdentity}` doesn't support `{_targetFramework.Name}`");
+                        resolvedDependencyGroup = packageMeta.DependencySets.FirstOrDefault(d => d.TargetFramework.Equals(NuGetFrameworkNetStandard20));
+
+                        if (resolvedDependencyGroup != null)
+                        {
+                            _logger.LogWarning($"The package `{packageIdentity}` doesn't support `{_targetFramework.Name}` but it has been resolved with `{NuGetFrameworkNetStandard20Id}`");
+                        }
+                    }
+
+                    if (resolvedDependencyGroup == null)
+                    {
+                        _logger.LogWarning($"The package `{packageIdentity}` doesn't support `{_targetFramework.Name}` or the minimum version `{NuGetFrameworkNetStandard20Id}`");
                         continue;
                     }
 

--- a/src/UnityNuGet/RegistryOptions.cs
+++ b/src/UnityNuGet/RegistryOptions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace UnityNuGet
+{
+    public class RegistryOptions
+    {
+        [Required]
+        public Uri RootHttpUrl { get; set; }
+
+        [Required]
+        [RegularExpression(@"[a-z]+\.[a-z]+")]
+        public string UnityScope { get; set; }
+
+        [Required]
+        [RegularExpression(@"\d+\.\d+")]
+        public string MinimumUnityVersion { get; set; }
+
+        [Required]
+        public string PackageNameNuGetPostFix { get; set; }
+
+        [Required]
+        public string RootPersistentFolder { get; set; }
+
+        [Required]
+        public TimeSpan UpdateInterval { get; set; }
+
+        [Required]
+        public RegistryTargetFramework TargetFramework { get; set; }
+    }
+
+    public class RegistryTargetFramework
+    {
+        [Required]
+        public string Name { get; set; }
+
+        [Required]
+        public string DefineConstraint { get; set; }
+    }
+}

--- a/src/UnityNuGet/UnityMeta.cs
+++ b/src/UnityNuGet/UnityMeta.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Scriban;
 
 namespace UnityNuGet
@@ -12,9 +14,6 @@ namespace UnityNuGet
         {
             switch (extension)
             {
-                case ".dll":
-                    return GetMetaForDll(guid);
-
                 case ".pdb":
                     break;
 
@@ -28,7 +27,7 @@ namespace UnityNuGet
             return null;
         }
 
-        private static string GetMetaForDll(Guid guid)
+        public static string GetMetaForDll(Guid guid, IEnumerable<string> defineConstraints)
         {
             const string text = @"fileFormatVersion: 2
 guid: {{ guid }}
@@ -38,7 +37,7 @@ PluginImporter:
   iconMap: {}
   executionOrder: {}
   defineConstraints:
-  - NET_STANDARD_2_0
+{{ constraints }}
   isPreloaded: 0
   isOverridable: 0
   isExplicitlyReferenced: 0
@@ -66,7 +65,7 @@ PluginImporter:
   assetBundleVariant: 
 ";
             var meta = Template.Parse(text);
-            return meta.Render(new { guid = guid.ToString("N") });
+            return meta.Render(new { guid = guid.ToString("N"), constraints = string.Join("\n", defineConstraints.Select(d => $"  - {d}").ToArray()) });
         }
 
         private static string GetMetaForText(Guid guid)

--- a/src/UnityNuGet/UnityNuGet.csproj
+++ b/src/UnityNuGet/UnityNuGet.csproj
@@ -16,14 +16,16 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-      <PackageReference Include="NuGet.Packaging" Version="5.8.1" />
-      <PackageReference Include="NuGet.Protocol" Version="5.8.1" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="NuGet.Packaging" Version="5.10.0" />
+      <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
       <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" /> 
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" /> 
-      <PackageReference Include="NuGet.Resolver" Version="5.8.1" /> 
-      <PackageReference Include="NUglify" Version="1.13.3" /> 
-      <PackageReference Include="Scriban" Version="3.5.0" /> 
-      <PackageReference Include="SharpZipLib" Version="1.3.1" />
+      <PackageReference Include="NuGet.Resolver" Version="5.10.0" /> 
+      <PackageReference Include="NUglify" Version="1.13.12" /> 
+      <PackageReference Include="Scriban" Version="4.0.1" /> 
+      <PackageReference Include="SharpZipLib" Version="1.3.2" /> 
+      <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>
 </Project>

--- a/src/UnityNuGet/UnityPackage.cs
+++ b/src/UnityNuGet/UnityPackage.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
-using UnityNuGet.Npm;
 
 namespace UnityNuGet
 {


### PR DESCRIPTION
@xoofx This PR is motivated by 2 reasons:
- Unity is including support for .NET Standard 2.1 in version 2021.2b.
- The server should be more configurable with environment variables to be able to serve custom NuGet repositories.

**Configuration**

The following variables have been exposed:
- Server root http url: {azure websites url}
- Unity scope: org.nuget
- Minimum Unity version: 2019.1
- Package name NuGet PostFix: " (NuGet)"
- Packages root folder path: unity_packages. In the development environment it is relative to the binary folder and in the production environment if an absolute path is provided it will take that one and if not it will add it to the working directory of the application.
- Packages Update Interval: 10 minutes
- Target Framework: netstandard2.0
- Unity define constraint: NET_STANDARD_2_0

They have been exposed through the Microsoft.Extensions.Configuration API which is very versatile as it can be configured in many ways like with a json file or with environment variables (useful with a Docker container).

I have configured in the appsettings.json file the default values as they were so that there are no breaking changes.

**Configuration validation**

Added Options.DataAnnotations API to validate the configuration.

**Dependencies**

Dependencies have been updated for all projects.

**Docker**

Complete example with all the configuration that can be modified and making an example of raising a container for .NET Standard 2.1.