### PR TITLE
Add ability to set custom define constraints for packages

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -51,6 +51,13 @@
     "listed": true,
     "version": "2.0.0"
   },
+  "H.InputSimulator": {
+    "listed": true,
+    "version": "1.0.8",
+    "defineConstraints": [
+      "UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN"
+    ]
+  },
   "Injecter": {
     "listed": true,
     "version": "1.0.0"

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -294,7 +294,7 @@ namespace UnityNuGet
                     // If we don't have any dependencies error, generate the package
                     if (!hasDependencyErrors)
                     {
-                        await ConvertNuGetToUnityPackageIfDoesNotExist(packageIdentity, npmPackageInfo, npmVersion, packageMeta, forceUpdate);
+                        await ConvertNuGetToUnityPackageIfDoesNotExist(packageIdentity, npmPackageInfo, npmVersion, packageMeta, forceUpdate, packageEntry);
                         npmPackage.Time[npmCurrentVersion] = packageMeta.Published?.UtcDateTime ?? GetUnityPackageFileInfo(packageIdentity, npmVersion).CreationTimeUtc;
 
                         // Copy repository info if necessary
@@ -326,7 +326,7 @@ namespace UnityNuGet
         /// <summary>
         /// Converts a NuGet package to Unity package if not already
         /// </summary>
-        private async Task ConvertNuGetToUnityPackageIfDoesNotExist(PackageIdentity identity, NpmPackageInfo npmPackageInfo, NpmPackageVersion npmPackageVersion, IPackageSearchMetadata packageMeta, bool forceUpdate)
+        private async Task ConvertNuGetToUnityPackageIfDoesNotExist(PackageIdentity identity, NpmPackageInfo npmPackageInfo, NpmPackageVersion npmPackageVersion, IPackageSearchMetadata packageMeta, bool forceUpdate, RegistryEntry packageEntry)
         {
             // If we need to force the update, we delete the previous package+sha1 files
             if (forceUpdate)
@@ -336,7 +336,7 @@ namespace UnityNuGet
 
             if (!IsUnityPackageValid(identity, npmPackageVersion) || !IsUnityPackageSha1Valid(identity, npmPackageVersion))
             {
-                await ConvertNuGetPackageToUnity(identity, npmPackageInfo, npmPackageVersion, packageMeta);
+                await ConvertNuGetPackageToUnity(identity, npmPackageInfo, npmPackageVersion, packageMeta, packageEntry);
             }
             else
             {
@@ -347,7 +347,7 @@ namespace UnityNuGet
         /// <summary>
         /// Converts a NuGet package to a Unity package.
         /// </summary>
-        private async Task ConvertNuGetPackageToUnity(PackageIdentity identity, NpmPackageInfo npmPackageInfo, NpmPackageVersion npmPackageVersion, IPackageSearchMetadata packageMeta)
+        private async Task ConvertNuGetPackageToUnity(PackageIdentity identity, NpmPackageInfo npmPackageInfo, NpmPackageVersion npmPackageVersion, IPackageSearchMetadata packageMeta, RegistryEntry packageEntry)
         {
             var unityPackageFileName = GetUnityPackageFileName(identity, npmPackageVersion);
             var unityPackageFilePath = Path.Combine(_rootPersistentFolder, unityPackageFileName);
@@ -439,7 +439,7 @@ namespace UnityNuGet
                                 // Otherwise, it means that the assembly is compatible with whatever netstandard, and we can simply
                                 // use NET_STANDARD
                                 var defineConstraints = hasMultiNetStandard || hasOnlyNetStandard21 || isPackageNetStandard21Assembly ? frameworks.First(x => x.Framework == item.TargetFramework).DefineConstraints : new[] { "" };
-                                meta = UnityMeta.GetMetaForDll(GetStableGuid(identity, fileInUnityPackage), defineConstraints);
+                                meta = UnityMeta.GetMetaForDll(GetStableGuid(identity, fileInUnityPackage), defineConstraints.Concat(packageEntry.DefineConstraints));
                             }
                             else
                             {

--- a/src/UnityNuGet/RegistryEntry.cs
+++ b/src/UnityNuGet/RegistryEntry.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 using NuGet.Versioning;
 
 namespace UnityNuGet
@@ -16,5 +17,8 @@ namespace UnityNuGet
 
         [JsonProperty("version")]
         public VersionRange Version { get; set; }
+
+        [JsonProperty("defineConstraints")]
+        public List<string> DefineConstraints { get; set; } = new();
     }
 }


### PR DESCRIPTION
That was easier than I expected.

I do not consider #40 entirely fixed because this doesn't add support for all managed plugin importer options. However, the ability to specify `#define` constraints *does* take you most of the way there.

`defineConstraints` can be specified as an array of strings, and they're pretty much passed directly to the generated `.meta` file. Therefore, you can use custom define constraints the same way as given in the [docs](https://docs.unity3d.com/Manual/PluginInspector.html).

Existing behavior for libraries that don't use custom defines is unchanged.

I've also added a plugin to demonstrate this feature. (I use H.InputSimulator to press the Play/Pause media key whenever I enter or exit Play Mode, so my music doesn't play over the game.)