### PR TITLE
Fix issue with isPreloaded being on the last define constraint line

### DIFF
--- a/src/UnityNuGet.Tests/UnityMetaTests.cs
+++ b/src/UnityNuGet.Tests/UnityMetaTests.cs
@@ -1,0 +1,31 @@
+using System;
+using NUnit.Framework;
+
+namespace UnityNuGet.Tests
+{
+    public class UnityMetaTests
+    {
+        [Test]
+        public void GetMetaForDll_FormatsDefineConstraintsProperly_WithoutConstraints()
+        {
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), Array.Empty<string>());
+            StringAssert.DoesNotContain("defineConstraints", output);
+
+            // This is on the same line in the template, so ensure it's intact
+            StringAssert.Contains("\n  isPreloaded: 0\n", output);
+        }
+
+        [TestCase(new[] { "FIRST" }, "\n  defineConstraints:\n  - FIRST\n")]
+        [TestCase(new[] { "FIRST", "SECOND" }, "\n  defineConstraints:\n  - FIRST\n  - SECOND\n")]
+        public void GetMetaForDll_FormatsDefineConstraintsProperly_WithConstraints(
+            string[] constraints, string expected)
+        {
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), constraints);
+
+            StringAssert.Contains(expected, output);
+
+            // This is on the same line in the template, so ensure it's intact
+            StringAssert.Contains("\n  isPreloaded: 0\n", output);
+        }
+    }
+}

--- a/src/UnityNuGet/AssemblyInfo.cs
+++ b/src/UnityNuGet/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("UnityNuGet.Tests")]

--- a/src/UnityNuGet/UnityMeta.cs
+++ b/src/UnityNuGet/UnityMeta.cs
@@ -63,11 +63,21 @@ PluginImporter:
   assetBundleVariant: 
 ";
 
-            ;
             var allConstraints = defineConstraints.ToList();
-            var meta = Template.Parse(text);
-            return meta.Render(new { guid = guid.ToString("N"), constraints = allConstraints.Count == 0 ? string.Empty : "  defineConstraints:\n" + string.Join("\n", allConstraints.Select(d => $"  - {d}").ToArray()) }
-            );
+
+            string FormatConstraints() => string.Join(
+                string.Empty,
+                allConstraints.Select(d => $"  - {d}\n"));
+
+            return Template
+                .Parse(text)
+                .Render(new
+                {
+                    guid = guid.ToString("N"),
+                    constraints = allConstraints.Count == 0
+                        ? string.Empty
+                        : $"  defineConstraints:\n{FormatConstraints()}"
+                });
         }
 
         public static string GetMetaForFolder(Guid guid)


### PR DESCRIPTION
https://github.com/xoofx/UnityNuGet/commit/f34133f23ed29867ecd5684f67aa9e686dcc9840 seems to have caused an issue where the define constraints can look like
```
  defineConstraints:
  - !UNITY_2021_2_OR_NEWER  isPreloaded: 0
```

This causes Unity to think the dll should never be referenced, thus breaking such packages. We faced this issue with at least `org.nuget.system.threading.tasks.extensions`.

This PR fixes this issue, along with tests and some style tweaks to make that code a bit more readable :)