### PR TITLE
Add Validation package

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -489,6 +489,10 @@
     "listed": true,
     "version": "0.8.6"
   },
+  "Validation": {
+    "listed": true,
+    "version": "2.5.42"
+  },
   "VoltRpc.Communication.Pipes": {
     "listed": true,
     "version": "1.0.0"

--- a/registry.json
+++ b/registry.json
@@ -433,6 +433,10 @@
     "listed": true,
     "version": "4.4.0"
   },
+  "System.Runtime.InteropServices": {
+    "listed": true,
+    "version": "4.1.0"
+  },
   "System.Security.Cryptography.Cng": {
     "listed": true,
     "version": "4.4.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Validation
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor **I'm using it right now.**
> - [ ] The package has been tested with a Unity standalone player **Admittedly, no, I haven't tested it in a build (as I haven't produced a standalone build for my current project in some time). However, looking at the source code reveals nothing obvious that would prevent it from working in a standalone build. (This library is basically a metric ass-ton of simple parameter checks.)**
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
