### PR TITLE
Add roslyn analyzers support

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -47,6 +47,11 @@
     "listed": true,
     "version": "0.0.2"
   },
+  "ErrorProne.NET.CoreAnalyzers": {
+    "listed": true,
+    "version": "0.1.2",
+    "analyzer": true
+  },
   "FastEnum": {
     "listed": true,
     "version": "1.0.0"
@@ -68,7 +73,7 @@
   },
   "K4os.Compression.LZ4": {
     "listed": true,
-    "version": "1.0.2" 
+    "version": "1.0.2"
   },
   "log4net": {
     "listed": true,
@@ -140,6 +145,11 @@
   "Microsoft.Bcl.HashCode": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "Microsoft.CodeAnalysis.NetAnalyzers": {
+    "listed": true,
+    "version": "5.0.3",
+    "analyzer": true
   },
   "Microsoft.Extensions.Caching.Abstractions": {
     "listed": true,
@@ -356,6 +366,11 @@
   "SixLabors.ImageSharp": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "SonarAnalyzer.CSharp": {
+    "listed": true,
+    "version": "8.30.0.37606",
+    "analyzer": true
   },
   "Stateless": {
     "listed": true,

--- a/src/UnityNuGet.Server/Controllers/ApiController.cs
+++ b/src/UnityNuGet.Server/Controllers/ApiController.cs
@@ -97,7 +97,8 @@ namespace UnityNuGet.Server.Controllers
             cacheInstance = instance;
             var currentIndex = _cacheSingleton.ProgressPackageIndex;
             var totalCount = _cacheSingleton.ProgressTotalPackageCount;
-            npmError = instance == null ? new NpmError("not_initialized", $"The server is initializing ({(totalCount != 0 ? (double)currentIndex * 100 / totalCount : 0):F1}% completed). Please retry later...") : null;
+            var percent = totalCount != 0 ? (double)currentIndex * 100 / totalCount : 0;
+            npmError = instance == null ? new NpmError("not_initialized", $"The server is initializing ({percent:F1}% completed). Please retry later...") : null;
 
             return instance != null;
         }

--- a/src/UnityNuGet.Server/NuGetRedirectLogger.cs
+++ b/src/UnityNuGet.Server/NuGetRedirectLogger.cs
@@ -8,7 +8,7 @@ using LogLevel = NuGet.Common.LogLevel;
 namespace UnityNuGet.Server
 {
     /// <summary>
-    /// A NuGet logger redirecting to a <see cref="Microsoft.Extensions.Logging.ILogger"/>
+    /// A NuGet logger redirecting to a <see cref="ILogger"/>
     /// </summary>
     public class NuGetRedirectLogger : LoggerBase
     {
@@ -32,23 +32,16 @@ namespace UnityNuGet.Server
 
         private static Microsoft.Extensions.Logging.LogLevel GetLogLevel(LogLevel logLevel)
         {
-            switch (logLevel)
+            return logLevel switch
             {
-                case LogLevel.Debug:
-                    return Microsoft.Extensions.Logging.LogLevel.Debug;
-                case LogLevel.Verbose:
-                    return Microsoft.Extensions.Logging.LogLevel.Trace;
-                case LogLevel.Information:
-                    return Microsoft.Extensions.Logging.LogLevel.Information;
-                case LogLevel.Minimal:
-                    return Microsoft.Extensions.Logging.LogLevel.Information;
-                case LogLevel.Warning:
-                    return Microsoft.Extensions.Logging.LogLevel.Warning;
-                case LogLevel.Error:
-                    return Microsoft.Extensions.Logging.LogLevel.Error;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null);
-            }
+                LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
+                LogLevel.Verbose => Microsoft.Extensions.Logging.LogLevel.Trace,
+                LogLevel.Information => Microsoft.Extensions.Logging.LogLevel.Information,
+                LogLevel.Minimal => Microsoft.Extensions.Logging.LogLevel.Information,
+                LogLevel.Warning => Microsoft.Extensions.Logging.LogLevel.Warning,
+                LogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
+                _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null),
+            };
         }
     }
 }

--- a/src/UnityNuGet.Server/RegistryCacheInitializer.cs
+++ b/src/UnityNuGet.Server/RegistryCacheInitializer.cs
@@ -28,7 +28,7 @@ namespace UnityNuGet.Server
             this.registryCacheSingleton = registryCacheSingleton;
         }
 
-        public async Task StartAsync(CancellationToken cancellationToken)
+        public Task StartAsync(CancellationToken cancellationToken)
         {
             var loggerRedirect = new NuGetRedirectLogger(loggerFactory.CreateLogger("NuGet"));
 
@@ -74,6 +74,8 @@ namespace UnityNuGet.Server
             registryCacheSingleton.UnityPackageFolder = unityPackageFolder;
             registryCacheSingleton.ServerUri = uri;
             registryCacheSingleton.NuGetRedirectLogger = loggerRedirect;
+
+            return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/UnityNuGet.Server/RegistryCacheSingleton.cs
+++ b/src/UnityNuGet.Server/RegistryCacheSingleton.cs
@@ -13,7 +13,7 @@ namespace UnityNuGet.Server
         public int ProgressPackageIndex { get; set; }
 
         public int ProgressTotalPackageCount { get; set; }
-        
+
         public RegistryCache Instance { get; set; }
     }
 }

--- a/src/UnityNuGet.Server/RegistryCacheUpdater.cs
+++ b/src/UnityNuGet.Server/RegistryCacheUpdater.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -32,13 +31,14 @@ namespace UnityNuGet.Server
                 {
                     _logger.LogInformation("Starting to update RegistryCache");
 
-                    var newRegistryCache = new RegistryCache(_currentRegistryCache.UnityPackageFolder, _currentRegistryCache.ServerUri, _registryOptions.UnityScope, _registryOptions.MinimumUnityVersion, _registryOptions.PackageNameNuGetPostFix, _registryOptions.TargetFrameworks, _currentRegistryCache.NuGetRedirectLogger);
-
-                    // Update progress
-                    newRegistryCache.OnProgress = (current, total) =>
+                    var newRegistryCache = new RegistryCache(_currentRegistryCache.UnityPackageFolder, _currentRegistryCache.ServerUri, _registryOptions.UnityScope, _registryOptions.MinimumUnityVersion, _registryOptions.PackageNameNuGetPostFix, _registryOptions.TargetFrameworks, _currentRegistryCache.NuGetRedirectLogger)
                     {
-                        _currentRegistryCache.ProgressTotalPackageCount = total;
-                        _currentRegistryCache.ProgressPackageIndex = current;
+                        // Update progress
+                        OnProgress = (current, total) =>
+                        {
+                            _currentRegistryCache.ProgressTotalPackageCount = total;
+                            _currentRegistryCache.ProgressPackageIndex = current;
+                        }
                     };
 
                     await newRegistryCache.Build();

--- a/src/UnityNuGet.Server/UnityNuGet.Server.csproj
+++ b/src/UnityNuGet.Server/UnityNuGet.Server.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.18.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.11" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="5.0.0" />
-        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
+        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UnityNuGet.Tests/RegistryCacheTests.cs
+++ b/src/UnityNuGet.Tests/RegistryCacheTests.cs
@@ -12,17 +12,16 @@ namespace UnityNuGet.Tests
         {
             var unityPackages = Path.Combine(Path.GetDirectoryName(typeof(RegistryCacheTests).Assembly.Location), "unity_packages");
             var registryCache = new RegistryCache(
-                unityPackages, 
-                new Uri("http://localhost/"), 
-                "org.nuget", 
-                "2019.1", 
-                " (NuGet)", 
+                unityPackages,
+                new Uri("http://localhost/"),
+                "org.nuget",
+                "2019.1",
+                " (NuGet)",
                 new RegistryTargetFramework[] {
                     new RegistryTargetFramework { Name = "netstandard2.1", DefineConstraints = new string[] { "UNITY_2021_2_OR_NEWER"} },
                     new RegistryTargetFramework { Name = "netstandard2.0", DefineConstraints = new string[] { "!UNITY_2021_2_OR_NEWER" } },
-                }, 
+                },
                 new NuGetConsoleLogger());
-
 
             // Uncomment when testing locally
             // registryCache.Filter = "scriban|bcl\\.asyncinterfaces|compilerservices\\.unsafe";

--- a/src/UnityNuGet.Tests/UnityMetaTests.cs
+++ b/src/UnityNuGet.Tests/UnityMetaTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using NUnit.Framework;
 
 namespace UnityNuGet.Tests
@@ -8,11 +8,21 @@ namespace UnityNuGet.Tests
         [Test]
         public void GetMetaForDll_FormatsDefineConstraintsProperly_WithoutConstraints()
         {
-            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), Array.Empty<string>());
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, Array.Empty<string>(), Array.Empty<string>());
             StringAssert.DoesNotContain("defineConstraints", output);
 
             // This is on the same line in the template, so ensure it's intact
             StringAssert.Contains("\n  isPreloaded: 0\n", output);
+        }
+
+        [Test]
+        public void GetMetaForDll_FormatsLabelsProperly_WithoutLabels()
+        {
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, Array.Empty<string>(), Array.Empty<string>());
+            StringAssert.DoesNotContain("labels", output);
+
+            // This is on the same line in the template, so ensure it's intact
+            StringAssert.Contains("\nPluginImporter:\n", output);
         }
 
         [TestCase(new[] { "FIRST" }, "\n  defineConstraints:\n  - FIRST\n")]
@@ -20,7 +30,7 @@ namespace UnityNuGet.Tests
         public void GetMetaForDll_FormatsDefineConstraintsProperly_WithConstraints(
             string[] constraints, string expected)
         {
-            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), constraints);
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, Array.Empty<string>(), constraints);
 
             StringAssert.Contains(expected, output);
 
@@ -28,10 +38,32 @@ namespace UnityNuGet.Tests
             StringAssert.Contains("\n  isPreloaded: 0\n", output);
         }
 
+        [TestCase(new[] { "FIRST" }, "\nlabels:\n  - FIRST\n")]
+        [TestCase(new[] { "FIRST", "SECOND" }, "\nlabels:\n  - FIRST\n  - SECOND\n")]
+        public void GetMetaForDll_FormatsLabelsProperly_WithLabels(
+            string[] labels, string expected)
+        {
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, labels, Array.Empty<string>());
+
+            StringAssert.Contains(expected, output);
+
+            // This is on the same line in the template, so ensure it's intact
+            StringAssert.Contains("\nPluginImporter:\n", output);
+        }
+
+        [TestCase(true, "1")]
+        [TestCase(false, "0")]
+        public void GetMetaForDll_FormatsAnyPlatformEnabledProperly(bool value, string expected)
+        {
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), value, Array.Empty<string>(), Array.Empty<string>());
+
+            StringAssert.Contains($"\n  platformData:\n  - first:\n      Any:\n    second:\n      enabled: {expected}\n", output);
+        }
+
         [Test]
         public void GetMetaForDll_ContainsNoWindowsNewlines()
         {
-            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), new[] {"TEST"});
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, Array.Empty<string>(), new[] { "TEST" });
             StringAssert.DoesNotContain("\r", output);
         }
     }

--- a/src/UnityNuGet.Tests/UnityNuGet.Tests.csproj
+++ b/src/UnityNuGet.Tests/UnityNuGet.Tests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="nunit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UnityNuGet/AssemblyInfo.cs
+++ b/src/UnityNuGet/AssemblyInfo.cs
@@ -1,3 +1,3 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
-[assembly:InternalsVisibleTo("UnityNuGet.Tests")]
+[assembly: InternalsVisibleTo("UnityNuGet.Tests")]

--- a/src/UnityNuGet/DotNetHelper.cs
+++ b/src/UnityNuGet/DotNetHelper.cs
@@ -12,7 +12,7 @@ namespace UnityNuGet
             return NetStandard21Assemblies.Contains(packageId);
         }
 
-        private static readonly HashSet<string> NetStandard21Assemblies = new HashSet<string>()
+        private static readonly HashSet<string> NetStandard21Assemblies = new()
         {
             "Microsoft.Win32.Primitives",
             "System.AppContext",

--- a/src/UnityNuGet/JsonCommonExtensions.cs
+++ b/src/UnityNuGet/JsonCommonExtensions.cs
@@ -16,7 +16,7 @@ namespace UnityNuGet
         /// <summary>
         /// Settings used for serializing JSON objects in this project.
         /// </summary>
-        public static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        public static readonly JsonSerializerSettings Settings = new()
         {
             MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
             DateParseHandling = DateParseHandling.None,

--- a/src/UnityNuGet/Npm/NpmError.cs
+++ b/src/UnityNuGet/Npm/NpmError.cs
@@ -7,7 +7,7 @@ namespace UnityNuGet.Npm
     /// </summary>
     public class NpmError : NpmObject
     {
-        public static readonly NpmError NotFound = new NpmError("not_found", "document not found");
+        public static readonly NpmError NotFound = new("not_found", "document not found");
 
         public NpmError(string error, string reason)
         {

--- a/src/UnityNuGet/Npm/NpmPackage.cs
+++ b/src/UnityNuGet/Npm/NpmPackage.cs
@@ -12,10 +12,10 @@ namespace UnityNuGet.Npm
         public NpmPackage()
         {
             Revision = "1-0";
-            DistTags = new Dictionary<string, string>();
-            Versions = new Dictionary<string, NpmPackageVersion>();
-            Time = new Dictionary<string, DateTime>();
-            Users = new Dictionary<string, string>();
+            DistTags = new();
+            Versions = new();
+            Time = new();
+            Users = new();
         }
 
         [JsonProperty("_id")]

--- a/src/UnityNuGet/Npm/NpmPackageInfo.cs
+++ b/src/UnityNuGet/Npm/NpmPackageInfo.cs
@@ -11,9 +11,9 @@ namespace UnityNuGet.Npm
     {
         public NpmPackageInfo()
         {
-            Maintainers = new List<string>();
-            Versions = new Dictionary<string, string>();
-            Keywords = new List<string>();
+            Maintainers = new();
+            Versions = new();
+            Keywords = new();
         }
 
         [JsonProperty("name")]

--- a/src/UnityNuGet/Npm/NpmPackageListAllResponse.cs
+++ b/src/UnityNuGet/Npm/NpmPackageListAllResponse.cs
@@ -15,7 +15,7 @@ namespace UnityNuGet.Npm
         public NpmPackageListAllResponse()
         {
             Unused = 99999;
-            Packages = new Dictionary<string, NpmPackageInfo>();
+            Packages = new();
         }
 
         [JsonProperty("_updated")]

--- a/src/UnityNuGet/Npm/NpmPackageRegistry.cs
+++ b/src/UnityNuGet/Npm/NpmPackageRegistry.cs
@@ -9,9 +9,9 @@ namespace UnityNuGet.Npm
     {
         public NpmPackageRegistry()
         {
-            Packages = new Dictionary<string, NpmPackage>();
-            ListedPackageInfos = new NpmPackageListAllResponse();
-            UnlistedPackageInfos = new NpmPackageListAllResponse();
+            Packages = new();
+            ListedPackageInfos = new();
+            UnlistedPackageInfos = new();
         }
 
         public Dictionary<string, NpmPackage> Packages { get; }

--- a/src/UnityNuGet/Npm/NpmPackageVersion.cs
+++ b/src/UnityNuGet/Npm/NpmPackageVersion.cs
@@ -10,9 +10,9 @@ namespace UnityNuGet.Npm
     {
         public NpmPackageVersion()
         {
-            Dependencies = new Dictionary<string, string>();
-            Distribution = new NpmDistribution();
-            Scripts = new Dictionary<string, string>();
+            Dependencies = new();
+            Distribution = new();
+            Scripts = new();
         }
 
         [JsonProperty("name")]

--- a/src/UnityNuGet/Registry.cs
+++ b/src/UnityNuGet/Registry.cs
@@ -16,6 +16,10 @@ namespace UnityNuGet
         private static readonly object LockRead = new();
         private static Registry _registry = null;
 
+        public Registry()
+        {
+        }
+
         private Registry(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }

--- a/src/UnityNuGet/Registry.cs
+++ b/src/UnityNuGet/Registry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
 namespace UnityNuGet
@@ -8,11 +9,16 @@ namespace UnityNuGet
     /// <summary>
     /// Loads the `registry.json` file at startup
     /// </summary>
+    [Serializable]
     public sealed class Registry : Dictionary<string, RegistryEntry>
     {
         private const string RegistryFileName = "registry.json";
         private static readonly object LockRead = new();
         private static Registry _registry = null;
+
+        private Registry(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
 
         public static Registry Parse(string json)
         {

--- a/src/UnityNuGet/Registry.cs
+++ b/src/UnityNuGet/Registry.cs
@@ -11,7 +11,7 @@ namespace UnityNuGet
     public sealed class Registry : Dictionary<string, RegistryEntry>
     {
         private const string RegistryFileName = "registry.json";
-        private static readonly object LockRead = new object();
+        private static readonly object LockRead = new();
         private static Registry _registry = null;
 
         public static Registry Parse(string json)

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -451,7 +451,7 @@ namespace UnityNuGet
                                 // Otherwise, it means that the assembly is compatible with whatever netstandard, and we can simply
                                 // use NET_STANDARD
                                 var defineConstraints = hasMultiNetStandard || hasOnlyNetStandard21 || isPackageNetStandard21Assembly ? frameworks.First(x => x.Framework == item.TargetFramework).DefineConstraints : Array.Empty<string>();
-                                meta = UnityMeta.GetMetaForDll(GetStableGuid(identity, fileInUnityPackage), defineConstraints.Concat(packageEntry.DefineConstraints));
+                                meta = UnityMeta.GetMetaForDll(GetStableGuid(identity, fileInUnityPackage), true, Array.Empty<string>(), defineConstraints.Concat(packageEntry.DefineConstraints));
                             }
                             else
                             {

--- a/src/UnityNuGet/RegistryEntry.cs
+++ b/src/UnityNuGet/RegistryEntry.cs
@@ -20,5 +20,8 @@ namespace UnityNuGet
 
         [JsonProperty("defineConstraints")]
         public List<string> DefineConstraints { get; set; } = new();
+
+        [JsonProperty("analyzer")]
+        public bool Analyzer { get; set; }
     }
 }

--- a/src/UnityNuGet/RegistryOptions.cs
+++ b/src/UnityNuGet/RegistryOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Newtonsoft.Json;
 using NuGet.Frameworks;

--- a/src/UnityNuGet/UnityNuGet.csproj
+++ b/src/UnityNuGet/UnityNuGet.csproj
@@ -19,14 +19,14 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-      <PackageReference Include="NuGet.Packaging" Version="5.10.0" />
-      <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
+      <PackageReference Include="NuGet.Packaging" Version="5.11.0" />
+      <PackageReference Include="NuGet.Protocol" Version="5.11.0" />
       <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" /> 
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0" /> 
-      <PackageReference Include="NuGet.Resolver" Version="5.10.0" /> 
-      <PackageReference Include="NUglify" Version="1.13.12" /> 
-      <PackageReference Include="Scriban" Version="4.0.1" /> 
-      <PackageReference Include="SharpZipLib" Version="1.3.2" /> 
+      <PackageReference Include="NuGet.Resolver" Version="5.11.0" /> 
+      <PackageReference Include="NUglify" Version="1.16.1" /> 
+      <PackageReference Include="Scriban" Version="5.0.0" /> 
+      <PackageReference Include="SharpZipLib" Version="1.3.3" /> 
       <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
I have taken the opportunity to update the solution packages and format the code according to the new language features.

I have also added 3 analyzer packages that I know.

I have been tempted to separate in several methods the code of the "ConvertNuGetPackageToUnity" method of "RegistryCache" but I have not dared to avoid a giant diff. It has to be split because it is starting to become a monster.