### PR TITLE
Added SharpZipLib

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -367,6 +367,10 @@
     "listed": true,
     "version": "0.24.0"
   },
+  "SharpZipLib": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "SixLabors.ImageSharp": {
     "listed": true,
     "version": "1.0.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package: https://www.nuget.org/packages/SharpZipLib
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well

SharpZipLib is also on OpenUPM. However, I'm making this pull request because the OpenUPM version the source files which also include the tests and more. Unity will complain about these extra files through warnings sometimes, hence why I made this PR. Having the SharpZipLib binary (through NuGet) is better for my use case and avoids including unused files.