### PR TITLE
Update registry.json

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -571,5 +571,9 @@
   "DotNetty.Codecs.ProtocolBuffers": {
     "listed": true,
     "version": "0.7.0"
+  },
+  "Google.Protobuf": {
+    "listed": true,
+    "version": "3.19.1"
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -531,5 +531,45 @@
   "VoltRpc": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "DotNetty.Common": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Buffers": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Transport": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Codecs": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Handlers": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Codecs.Mqtt": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Codecs.Http": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Codecs.Protobuf": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Codecs.Redis": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Codecs.ProtocolBuffers": {
+    "listed": true,
+    "version": "0.7.0"
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -572,8 +572,12 @@
     "listed": true,
     "version": "0.7.0"
   },
+  "DotNetty.Transport.Libuv": {
+    "listed": true,
+    "version": "0.7.0"
+  },
   "Google.Protobuf": {
     "listed": true,
-    "version": "3.19.1"
+    "version": "3.8.0"
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -564,18 +564,6 @@
     "listed": true,
     "version": "0.7.0"
   },
-  "DotNetty.Codecs.Redis": {
-    "listed": true,
-    "version": "0.7.0"
-  },
-  "DotNetty.Codecs.ProtocolBuffers": {
-    "listed": true,
-    "version": "0.7.0"
-  },
-  "DotNetty.Transport.Libuv": {
-    "listed": true,
-    "version": "0.7.0"
-  },
   "Google.Protobuf": {
     "listed": true,
     "version": "3.8.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: 
https://www.nuget.org/packages/DotNetty.Common/
https://www.nuget.org/packages/DotNetty.Buffers/
https://www.nuget.org/packages/DotNetty.Transport/
https://www.nuget.org/packages/DotNetty.Codecs/
https://www.nuget.org/packages/DotNetty.Handlers/
https://www.nuget.org/packages/DotNetty.Codecs.Mqtt/
https://www.nuget.org/packages/DotNetty.Codecs.Http/
https://www.nuget.org/packages/DotNetty.Codecs.Protobuf/
https://www.nuget.org/packages/Google.Protobuf/
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [ ] The package has been tested with the Unity editor 
> - [ ] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [ ] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
