### PR TITLE
Add Polly

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -215,6 +215,10 @@
     "listed": true,
     "version": "3.0.0"
   },
+  "Microsoft.Extensions.Features": {
+    "listed": true,
+    "version": "6.0.0"
+  },
   "Microsoft.Extensions.FileProviders.Abstractions": {
     "listed": true,
     "version": "2.0.0"
@@ -240,6 +244,10 @@
     "version": "2.0.0"
   },
   "Microsoft.Extensions.Http": {
+    "listed": true,
+    "version": "2.1.0"
+  },
+  "Microsoft.Extensions.Http.Polly": {
     "listed": true,
     "version": "2.1.0"
   },
@@ -311,6 +319,14 @@
     "listed": true,
     "version": "11.0.1"
   },
+  "Polly": {
+    "listed": true,
+    "version": "6.0.1"
+  },
+  "Polly.Extensions.Http": {
+    "listed": true,
+    "version": "2.0.1"
+  },
   "Prism.Core": {
     "listed": true,
     "version": "7.0.0.362"
@@ -335,7 +351,7 @@
     "listed": true,
     "version": "2.9.0"
   },
-  "Serilog.Extensions.Logging":{
+  "Serilog.Extensions.Logging": {
     "listed": true,
     "version": "3.1.0"
   },


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Polly
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
