### PR TITLE
Add multiple analyzers and source generators

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -182,14 +182,14 @@
     "version": "2.9.0",
     "analyzer": true
   },
-  "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
-    "listed": true,
-    "version": "2.9.0",
-    "analyzer": true
-  },
   "Microsoft.CodeAnalysis.NetAnalyzers": {
     "listed": true,
     "version": "5.0.3",
+    "analyzer": true
+  },
+  "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
+    "listed": true,
+    "version": "2.9.0",
     "analyzer": true
   },
   "Microsoft.CSharp": {

--- a/registry.json
+++ b/registry.json
@@ -91,7 +91,7 @@
       "UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN"
     ]
   },
-  "IDisposableAnalyzers":{
+  "IDisposableAnalyzers": {
     "listed": true,
     "version": "1.0.0",
     "analyzer": true
@@ -177,12 +177,12 @@
     "listed": true,
     "version": "1.0.0"
   },
-  "Microsoft.CodeAnalysis.BannedApiAnalyzers":{
+  "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
     "listed": true,
     "version": "2.9.0",
     "analyzer": true
   },
-  "Microsoft.CodeAnalysis.PublicApiAnalyzers":{
+  "Microsoft.CodeAnalysis.PublicApiAnalyzers": {
     "listed": true,
     "version": "2.9.0",
     "analyzer": true
@@ -355,7 +355,7 @@
     "listed": true,
     "version": "2.0.0"
   },
-  "Microsoft.Toolkit.Mvvm":{
+  "Microsoft.Toolkit.Mvvm": {
     "listed": true,
     "version": "7.0.0",
     "analyzer": true
@@ -409,7 +409,7 @@
     "listed": true,
     "version": "106.10.0"
   },
-  "Roslynator.Analyzers":{
+  "Roslynator.Analyzers": {
     "listed": true,
     "version": "1.2.0",
     "analyzer": true
@@ -471,12 +471,12 @@
     "listed": true,
     "version": "4.3.0"
   },
-  "StrongInject":{
+  "StrongInject": {
     "listed": true,
     "version": "1.0.0",
     "analyzer": true
   },
-  "StrongInject.Extensions.DependencyInjection":{
+  "StrongInject.Extensions.DependencyInjection": {
     "listed": true,
     "version": "0.0.1"
   },

--- a/registry.json
+++ b/registry.json
@@ -167,6 +167,16 @@
     "listed": true,
     "version": "1.0.0"
   },
+  "Microsoft.CodeAnalysis.BannedApiAnalyzers":{
+    "listed": true,
+    "version": "2.9.0",
+    "analyzer": true
+  },
+  "Microsoft.CodeAnalysis.PublicApiAnalyzers":{
+    "listed": true,
+    "version": "2.9.0",
+    "analyzer": true
+  },
   "Microsoft.CodeAnalysis.NetAnalyzers": {
     "listed": true,
     "version": "5.0.3",

--- a/registry.json
+++ b/registry.json
@@ -446,6 +446,15 @@
     "listed": true,
     "version": "4.3.0"
   },
+  "StrongInject":{
+    "listed": true,
+    "version": "1.0.0",
+    "analyzer": true
+  },
+  "StrongInject.Extensions.DependencyInjection":{
+    "listed": true,
+    "version": "0.0.1"
+  },
   "System.Buffers": {
     "listed": true,
     "version": "4.4.0"

--- a/registry.json
+++ b/registry.json
@@ -335,6 +335,11 @@
     "listed": true,
     "version": "2.0.0"
   },
+  "Microsoft.Toolkit.Mvvm":{
+    "listed": true,
+    "version": "7.0.0",
+    "analyzer": true
+  },
   "morelinq": {
     "listed": true,
     "version": "3.2.0"

--- a/registry.json
+++ b/registry.json
@@ -91,6 +91,11 @@
       "UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN"
     ]
   },
+  "IDisposableAnalyzers":{
+    "listed": true,
+    "version": "1.0.0",
+    "analyzer": true
+  },
   "Injecter": {
     "listed": true,
     "version": "1.0.0"

--- a/registry.json
+++ b/registry.json
@@ -120,6 +120,11 @@
     "listed": true,
     "version": "2.1.80"
   },
+  "Meziantou.Analyzer": {
+    "listed": true,
+    "version": "1.0.349",
+    "analyzer": true
+  },
   "Microsoft.AspNetCore.Connections.Abstractions": {
     "listed": true,
     "version": "2.1.0"

--- a/registry.json
+++ b/registry.json
@@ -360,6 +360,11 @@
     "version": "7.0.0",
     "analyzer": true
   },
+  "Microsoft.Unity.Analyzers": {
+    "listed": true,
+    "version": "1.7.0",
+    "analyzer": true
+  },
   "Microsoft.VisualStudio.Threading.Analyzers": {
     "listed": true,
     "version": "16.3.13",

--- a/registry.json
+++ b/registry.json
@@ -379,6 +379,11 @@
     "listed": true,
     "version": "106.10.0"
   },
+  "Roslynator.Analyzers":{
+    "listed": true,
+    "version": "1.2.0",
+    "analyzer": true
+  },
   "Scriban": {
     "listed": true,
     "version": "2.1.0"

--- a/registry.json
+++ b/registry.json
@@ -476,10 +476,6 @@
     "version": "1.0.0",
     "analyzer": true
   },
-  "StrongInject.Extensions.DependencyInjection": {
-    "listed": true,
-    "version": "0.0.1"
-  },
   "System.Buffers": {
     "listed": true,
     "version": "4.4.0"

--- a/registry.json
+++ b/registry.json
@@ -360,6 +360,11 @@
     "version": "7.0.0",
     "analyzer": true
   },
+  "Microsoft.VisualStudio.Threading.Analyzers": {
+    "listed": true,
+    "version": "16.3.13",
+    "analyzer": true
+  },
   "morelinq": {
     "listed": true,
     "version": "3.2.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package:
>  - https://www.nuget.org/packages/IDisposableAnalyzers/
>  - https://www.nuget.org/packages/Meziantou.Analyzer/
>  - https://www.nuget.org/packages/Microsoft.CodeAnalysis.BannedApiAnalyzers/
>  - https://www.nuget.org/packages/Microsoft.CodeAnalysis.PublicApiAnalyzers/
>  - https://www.nuget.org/packages/Microsoft.Toolkit.Mvvm/
>  - https://www.nuget.org/packages/Microsoft.VisualStudio.Threading.Analyzers/
>  - https://www.nuget.org/packages/Roslynator.Analyzers/
>  - https://www.nuget.org/packages/StrongInject
>  - https://www.nuget.org/packages/Microsoft.Unity.Analyzers
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
