### PR TITLE
Add Google.Protobuf

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -60,6 +60,10 @@
     "listed": true,
     "version": "2.0.0"
   },
+  "Google.Protobuf": {
+    "listed": true,
+    "version": "3.8.0"
+  }
   "Grpc.Core": {
     "listed": true,
     "version": "1.20.0"

--- a/registry.json
+++ b/registry.json
@@ -63,7 +63,7 @@
   "Google.Protobuf": {
     "listed": true,
     "version": "3.8.0"
-  }
+  },
   "Grpc.Core": {
     "listed": true,
     "version": "1.20.0"


### PR DESCRIPTION
Originally proposed in #71, This is a much smaller addition that only adds Protobuf 
This is the standard Protobuf dependency for generated Csharp code.

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: 
        Earliest: https://www.nuget.org/packages/Google.Protobuf/3.8.0
        Current: https://www.nuget.org/packages/Google.Protobuf/3.19.1
  > - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
          Deps, already in the registry:
              System.Memory (>= 4.5.3)
              System.Runtime.CompilerServices.Unsafe (>= 4.5.2)
  >   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
