### PR TITLE
Create target framework folder meta file only if it contains files

### DIFF
--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -559,7 +559,7 @@ namespace UnityNuGet
                         }
 
                         // Write folder meta
-                        if (!string.IsNullOrEmpty(folderPrefix))
+                        if (!string.IsNullOrEmpty(folderPrefix) && item.Items.Any())
                         {
                             // write meta file for the folder
                             WriteTextFileToTar(tarArchive, $"{folderPrefix[0..^1]}.meta", UnityMeta.GetMetaForFolder(GetStableGuid(identity, folderPrefix)));


### PR DESCRIPTION
There are packages such as System.Reflection.Emit, which target both .NET Standard 2.0 and 2.1:

![image](https://user-images.githubusercontent.com/950602/147678453-2e750ecb-53d3-4c6f-8004-05b63b3d9985.png)

The problem is that in case of 2.1, it does not have files so with the current code it will generate the *.meta file of the netstandard2.1 folder without checking if files have been generated, that is, if the folder is going to be empty or not. In case it is empty it should not generate the *.meta file.

![image](https://user-images.githubusercontent.com/950602/147678385-910543dd-e010-45bf-b9a3-265848b4618b.png)

This code fixes that problem.