### PR TITLE
Add UnitsNet

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -489,8 +489,8 @@
     "version": "1.0.0",
     "analyzer": true
   },
-  "StrongInject.Extensions.DependencyInjection":{
-    "listed":true,
+  "StrongInject.Extensions.DependencyInjection": {
+    "listed": true,
     "version": "1.4.1"
   },
   "System.Buffers": {
@@ -632,6 +632,18 @@
   "Telnet": {
     "listed": true,
     "version": "0.8.6"
+  },
+  "UnitsNet": {
+    "listed": true,
+    "version": "4.101.0"
+  },
+  "UnitsNet.NumberExtensions": {
+    "listed": true,
+    "version": "4.101.0"
+  },
+  "UnitsNet.Serialization.JsonNet": {
+    "listed": true,
+    "version": "4.5.0"
   },
   "Validation": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package:
>  - https://www.nuget.org/packages/UnitsNet/4.101.0
>  - https://www.nuget.org/packages/UnitsNet.NumberExtensions/4.101.0
>  - https://www.nuget.org/packages/UnitsNet.Serialization.JsonNet/4.5.0
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
