### PR TITLE
Add Rhino3dm + support for native libs (Standalone platform only)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -428,7 +428,7 @@
   },
   "Robots": {
     "listed": true,
-    "version": "1.1.4"
+    "version": "1.1.5"
   },
   "Roslynator.Analyzers": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -426,6 +426,10 @@
     "listed": true,
     "version": "7.11.0"
   },
+  "Robots": {
+    "listed": true,
+    "version": "1.1.4"
+  },
   "Roslynator.Analyzers": {
     "listed": true,
     "version": "1.2.0",

--- a/registry.json
+++ b/registry.json
@@ -112,9 +112,9 @@
     "listed": true,
     "version": "2.0.11"
   },
-  "MathNet.Numerics":{
-    "listed":true,
-    "version":"4.0.0"
+  "MathNet.Numerics": {
+    "listed": true,
+    "version": "4.0.0"
   },
   "McMaster.Extensions.CommandLineUtils": {
     "listed": true,
@@ -421,6 +421,10 @@
   "RestSharp.Serializers.SystemTextJson": {
     "listed": true,
     "version": "106.10.0"
+  },
+  "Rhino3dm": {
+    "listed": true,
+    "version": "7.11.0"
   },
   "Roslynator.Analyzers": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -424,7 +424,7 @@
   },
   "Rhino3dm": {
     "listed": true,
-    "version": "7.11.0"
+    "version": "7.6.0"
   },
   "Robots": {
     "listed": true,

--- a/src/UnityNuGet.Tests/NativeTests.cs
+++ b/src/UnityNuGet.Tests/NativeTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 
 namespace UnityNuGet.Tests
 {
+    [Ignore("Ignore native libs tests")]
     public class NativeTests
     {
         [Test]

--- a/src/UnityNuGet.Tests/NativeTests.cs
+++ b/src/UnityNuGet.Tests/NativeTests.cs
@@ -11,6 +11,8 @@ namespace UnityNuGet.Tests
         public async Task TestBuild()
         {
             var unityPackages = Path.Combine(Path.GetDirectoryName(typeof(RegistryCacheTests).Assembly.Location), "unity_packages");
+            Directory.Delete(unityPackages, true);
+
             var registryCache = new RegistryCache(
                 unityPackages,
                 new Uri("http://localhost/"),

--- a/src/UnityNuGet.Tests/NativeTests.cs
+++ b/src/UnityNuGet.Tests/NativeTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace UnityNuGet.Tests
+{
+    public class NativeTests
+    {
+        [Test]
+        public async Task TestBuild()
+        {
+            var unityPackages = Path.Combine(Path.GetDirectoryName(typeof(RegistryCacheTests).Assembly.Location), "unity_packages");
+            var registryCache = new RegistryCache(
+                unityPackages,
+                new Uri("http://localhost/"),
+                "org.nuget",
+                "2019.1",
+                " (NuGet)",
+                new RegistryTargetFramework[] {
+                    new RegistryTargetFramework { Name = "netstandard2.1", DefineConstraints = new string[] { "UNITY_2021_2_OR_NEWER"} },
+                    new RegistryTargetFramework { Name = "netstandard2.0", DefineConstraints = new string[] { "!UNITY_2021_2_OR_NEWER" } },
+                },
+                new NuGetConsoleLogger())
+            {
+                Filter = "rhino3dm"
+            };
+
+            await registryCache.Build();
+
+            Assert.False(registryCache.HasErrors, "The registry failed to build, check the logs");
+            var allResult = registryCache.All();
+            var allResultJson = allResult.ToJson();
+
+            StringAssert.Contains("org.nuget.rhino3dm", allResultJson);
+
+            var rhinoPackage = registryCache.GetPackage("org.nuget.rhino3dm");
+            Assert.NotNull(rhinoPackage);
+            var rhinopackageJson = rhinoPackage.ToJson();
+            StringAssert.Contains("org.nuget.rhino3dm", rhinopackageJson);
+            StringAssert.Contains("7.11.0", rhinopackageJson);
+        }
+    }
+}

--- a/src/UnityNuGet/NativeLibraries.cs
+++ b/src/UnityNuGet/NativeLibraries.cs
@@ -23,7 +23,6 @@ namespace UnityNuGet
 
                 if (folders.Length != 3 || !folders[2].Equals("native", StringComparison.OrdinalIgnoreCase))
                 {
-
                     logger.LogInformation($"Skipping non-native library file located in the runtimes folder: {file} ...");
                     continue;
                 }

--- a/src/UnityNuGet/NativeLibraries.cs
+++ b/src/UnityNuGet/NativeLibraries.cs
@@ -11,7 +11,7 @@ namespace UnityNuGet
 {
     static class NativeLibraries
     {
-        public static async IAsyncEnumerable<(string file, string platform, string architecture)> GetSupportedNativeLibsAsync(PackageReaderBase packageReader, ILogger logger)
+        public static async IAsyncEnumerable<(string file, string[] folders, string platform, string architecture)> GetSupportedNativeLibsAsync(PackageReaderBase packageReader, ILogger logger)
         {
             var versions = await packageReader.GetItemsAsync(PackagingConstants.Folders.Runtimes, CancellationToken.None);
             var files = versions.SelectMany(v => v.Items);
@@ -63,7 +63,7 @@ namespace UnityNuGet
                     continue;
                 }
 
-                yield return (file, platform, architecture);
+                yield return (file, folders, platform, architecture);
             }
         }
 

--- a/src/UnityNuGet/NativeLibraries.cs
+++ b/src/UnityNuGet/NativeLibraries.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Threading;
+using NuGet.Packaging;
+using NuGet.Common;
+using Scriban;
+
+namespace UnityNuGet
+{
+    static class NativeLibraries
+    {
+        public static async IAsyncEnumerable<(string file, string platform, string architecture)> GetSupportedNativeLibsAsync(PackageReaderBase packageReader, ILogger logger)
+        {
+            var versions = await packageReader.GetItemsAsync(PackagingConstants.Folders.Runtimes, CancellationToken.None);
+            var files = versions.SelectMany(v => v.Items);
+
+            foreach (var file in files)
+            {
+                var folderPath = Path.GetDirectoryName(file);
+                var folders = folderPath.Split(Path.DirectorySeparatorChar);
+
+                if (folders.Length != 3 || !folders[2].Equals("native", StringComparison.OrdinalIgnoreCase))
+                {
+
+                    logger.LogInformation($"Skipping non-native library file located in the runtimes folder: {file} ...");
+                    continue;
+                }
+
+                var system = folders[1].Split('-');
+
+                if (system.Length != 2)
+                {
+                    logger.LogInformation($"Skipping file located in the runtime folder that does not specify platform and architecture: {file} ...");
+                    continue;
+                }
+
+                var platform = system[0][..3] switch
+                {
+                    "lin" => "Linux",
+                    "osx" => "OSX",
+                    "win" => "Windows",
+                    _ => null
+                };
+
+                if (platform is null)
+                {
+                    logger.LogInformation($"Skipping file for unsupported platform: {file} ...");
+                    continue;
+                }
+
+                var architecture = system[1] switch
+                {
+                    "x86" => "x86",
+                    "x64" => "x86_64",
+                    "arm64" => "ARM64",
+                    _ => null
+                };
+
+                if (architecture is null)
+                {
+                    logger.LogInformation($"Skipping file for unsupported architecture: {file} ...");
+                    continue;
+                }
+
+                yield return (file, platform, architecture);
+            }
+        }
+
+        public static string GetMetaForNative(Guid guid, string platform, string architecture, string[] labels)
+        {
+            // (Editor, Linux64, OSXUniversal, Win, Win64)
+            var enables = (platform, architecture) switch
+            {
+                ("Linux", _) => (1, 1, 0, 0, 0),
+                ("OSX", _) => (1, 0, 1, 0, 0),
+                ("Windows", "x86") => (0, 0, 0, 1, 0),
+                ("Windows", "x86_64") => (1, 0, 0, 0, 1),
+                _ => throw new ArgumentException("Unsupported configuration")
+            };
+
+            const string text = @"{{ cpu(x) = x == 1 ? architecture : ""None"" }}fileFormatVersion: 2
+guid: {{ guid }}
+{{ labels }}PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: {{ 1 - enables.item1 }}
+        Exclude Linux64: {{ 1 - enables.item2 }}
+        Exclude OSXUniversal: {{ 1 - enables.item3 }}
+        Exclude Win: {{ 1 - enables.item4 }}
+        Exclude Win64: {{ 1 - enables.item5 }}
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: {{ enables.item1 }}
+      settings:
+        CPU: {{ cpu enables.item1 }}
+        DefaultValueInitialized: true
+        OS: {{ enables.item1 == 1 ? platform : ""None"" }}
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: {{ enables.item2 }}
+      settings:
+        CPU: {{ cpu enables.item2 }}
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: {{ enables.item3 }}
+      settings:
+        CPU: {{ cpu enables.item3 }}
+  - first:
+      Standalone: Win
+    second:
+      enabled: {{ enables.item4 }}
+      settings:
+        CPU: {{ cpu enables.item4 }}
+  - first:
+      Standalone: Win64
+    second:
+      enabled: {{ enables.item5 }}
+      settings:
+        CPU: {{ cpu enables.item5 }}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+";
+
+            return Template
+                .Parse(text)
+                .Render(new
+                {
+                    guid = guid.ToString("N"),
+                    enables,
+                    platform,
+                    architecture,
+                    labels = labels.Length == 0
+                    ? string.Empty
+                    : $"labels:\n{string.Concat(labels.Select(l => $"  - {l}\n"))}",
+                })
+                .Replace("\r\n", "\n");
+        }
+    }
+}

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -575,7 +575,7 @@ namespace UnityNuGet
                     var nativeFiles = NativeLibraries.GetSupportedNativeLibsAsync(packageReader, _logger);
                     var nativeFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                    await foreach (var (file, platform, architecture) in nativeFiles)
+                    await foreach (var (file, folders, platform, architecture) in nativeFiles)
                     {
                         string extension = Path.GetExtension(file);
                         string meta = extension switch
@@ -593,10 +593,9 @@ namespace UnityNuGet
                         WriteTextFileToTar(tarArchive, $"{file}.meta", meta);
 
                         // Remember all folders for meta files
-                        var folderPath = Path.GetDirectoryName(file);
                         string folder = "";
 
-                        foreach (var relative in folderPath.Split(Path.DirectorySeparatorChar))
+                        foreach (var relative in folders)
                         {
                             folder = Path.Combine(folder, relative);
                             nativeFolders.Add(folder);


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Rhino3dm/ and https://www.nuget.org/packages/Robots/
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well

## Native libraries
- Closes #90
- This PR adds support for native libraries for desktop applications.
- It checks for files in the package that are placed under `runtimes\{platform}-{architecture}\native` 
- It will copy them if they have the win, linux, or osx platforms and x86, x64, or arm64 architectures.
- It will create meta files for the Standalone platform.
- Other files are ignored.

It has only been tested with the Rhino3dm package in Windows 10. If there is interest in other packages I can check them and adjust the code if necessary.

### Possible issues
There can't be two files with the same name targeting the same combination of platform and architecture. This happens mainly when two files for different architectures are enabled to run in the Unity Editor. For Windows, only x64 is used in the editor and x86 is ignored. 

I guess for Mac, for example, there could be a package that contains both x64 and arm64 (for the new M1 chip), which one to use in the editor would depend on the Mac and Unity version. I haven't considered how to work around this issue.

