### PR TITLE
Add Google.Apis.AndroidPublisher.v3 and it's dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -60,6 +60,22 @@
     "listed": true,
     "version": "2.0.0"
   },
+  "Google.Apis": {
+    "listed": true,
+    "version": "1.35.0"
+  },
+  "Google.Apis.AndroidPublisher.v3": {
+    "listed": true,
+    "version": "1.35.1.1312"
+  },
+  "Google.Apis.Auth": {
+    "listed": true,
+    "version": "1.35.0"
+  },
+  "Google.Apis.Core": {
+    "listed": true,
+    "version": "1.35.0"
+  },
   "Google.Protobuf": {
     "listed": true,
     "version": "3.8.0"

--- a/registry.json
+++ b/registry.json
@@ -62,19 +62,19 @@
   },
   "Google.Apis": {
     "listed": true,
-    "version": "1.35.0"
+    "version": "1.44.0"
   },
   "Google.Apis.AndroidPublisher.v3": {
     "listed": true,
-    "version": "1.35.1.1312"
+    "version": "1.44.0.1872"
   },
   "Google.Apis.Auth": {
     "listed": true,
-    "version": "1.35.0"
+    "version": "1.44.0"
   },
   "Google.Apis.Core": {
     "listed": true,
-    "version": "1.35.0"
+    "version": "1.44.0"
   },
   "Google.Protobuf": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package: https://www.nuget.org/packages/Google.Apis.AndroidPublisher.v3/
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor
> - [ ] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well

This package provides API access to the Google Play Console to manipulate the Google Play Store contents for android application developers and publishers.
Our workflow involves usage from the Unity editor only, so standalone player has not been tested.