### PR TITLE
Add ComradeVanti.CSharpTools.Opt

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -39,6 +39,10 @@
     "listed": true,
     "version": "2.4.0"
   },
+  "ComradeVanti.CSharpTools.Opt": {
+    "listed": true,
+    "version": "1.0.2"
+  },
   "CsvHelper": {
     "listed": true,
     "version": "3.0.0"


### PR DESCRIPTION
Opt is a C# library for bringing F# optionals to the language

- Link: https://www.nuget.org/packages/ComradeVanti.CSharpTools.Opt/
- Current version is 1.1.2
- .NetStandard 2.0 is included from 1.0.2 upwards
- I already made a [Unity package](https://github.com/ComradeVanti/opt-unity) using the library as a dll so editor and standalone was tested
- This library has no dependencies
- I don't expect this library to have dependencies in the future

Edit: The repo can be found [here](https://github.com/ComradeVanti/opt-csharp)