### PR TITLE
Add IsExternalInit.System.Runtime.CompilerServices

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -120,6 +120,10 @@
     "listed": true,
     "version": "1.0.0"
   },
+  "IsExternalInit.System.Runtime.CompilerServices": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "Jdenticon-net": {
     "listed": true,
     "version": "2.2.0"


### PR DESCRIPTION
- Enables the use of `init` syntax and `record` types. (Does **not** enable serialization support for records.)
- Source repo is [here](https://github.com/asynkron/IsExternalInit).
- Unity 2021.2 technically supports C# 9, just not all of its features. This package plugs a few holes. See [here](https://docs.unity3d.com/2021.2/Documentation/Manual/CSharpCompiler.html) for more details.

Once Unity supports this feature natively, I'll come back and add `#define` constraints to prevent conflicts.

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/IsExternalInit.System.Runtime.CompilerServices/
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1) **Just one release.**
> - [x] It must provide .NETStandard2.0 assemblies as part of its package **.NET Standard 2.1 okay?**
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available **Just one release.**
> - [x] The package has been tested with the Unity editor **Using it right now.**
> - [x] The package has been tested with a Unity standalone player **The manual already says it's okay.**
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above) **No dependencies.**
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
