### PR TITLE
Add ComradeVanti.CSharpTools.Res

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -43,6 +43,10 @@
     "listed": true,
     "version": "1.0.2"
   },
+   "ComradeVanti.CSharpTools.Res": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "CsvHelper": {
     "listed": true,
     "version": "3.0.0"


### PR DESCRIPTION
Res is a C# library for bringing F# results to the language
- Link: https://www.nuget.org/packages/ComradeVanti.CSharpTools.Res/
- Current version is 1.0.0
- .NetStandard 2.0 is included
- The library was lightly tested in the editor and standalone windows
- The library has no dependencies
- I don't expect this library to have dependencies in the future
- The repo is [here](https://github.com/ComradeVanti/res-csharp)
