### PR TITLE
Add Microsoft.EntityFrameworkCore 3.1.X

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -31,6 +31,10 @@
     "listed": true,
     "version": "1.0.0"
   },
+  "Castle.Core": {
+    "listed": true,
+    "version": "4.4.0"
+  },
   "CircularBuffer": {
     "listed": true,
     "version": "1.1.0"

--- a/registry.json
+++ b/registry.json
@@ -238,31 +238,31 @@
   },
   "Microsoft.EntityFrameworkCore": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "Microsoft.EntityFrameworkCore.Abstractions": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "Microsoft.EntityFrameworkCore.Analyzers": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "Microsoft.EntityFrameworkCore.Proxies": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "Microsoft.EntityFrameworkCore.Relational": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "Microsoft.EntityFrameworkCore.Sqlite": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "Microsoft.EntityFrameworkCore.Sqlite.Core": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "Microsoft.Extensions.Caching.Abstractions": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -237,31 +237,31 @@
     "ignore": true
   },
   "Microsoft.EntityFrameworkCore": {
-    "listed": false,
+    "listed": true,
     "version": "3.0.0"
   },
   "Microsoft.EntityFrameworkCore.Abstractions": {
-    "listed": false,
+    "listed": true,
     "version": "3.0.0"
   },
   "Microsoft.EntityFrameworkCore.Analyzers": {
-    "listed": false,
+    "listed": true,
     "version": "3.0.0"
   },
   "Microsoft.EntityFrameworkCore.Proxies": {
-    "listed": false,
+    "listed": true,
     "version": "3.0.0"
   },
   "Microsoft.EntityFrameworkCore.Relational": {
-    "listed": false,
+    "listed": true,
     "version": "3.0.0"
   },
   "Microsoft.EntityFrameworkCore.Sqlite": {
-    "listed": false,
+    "listed": true,
     "version": "3.0.0"
   },
   "Microsoft.EntityFrameworkCore.Sqlite.Core": {
-    "listed": false,
+    "listed": true,
     "version": "3.0.0"
   },
   "Microsoft.Extensions.Caching.Abstractions": {

--- a/registry.json
+++ b/registry.json
@@ -33,7 +33,7 @@
   },
   "Castle.Core": {
     "listed": true,
-    "version": "5.0.0",
+    "version": "4.4.0",
     "defineConstraints": [
       "UNITY_EDITOR"
     ]
@@ -256,6 +256,15 @@
   "Microsoft.CSharp": {
     "ignore": true
   },
+  "Microsoft.Data.Sqlite.Core": {
+    "listed": true,
+    "version": "3.1.0"
+  },
+  "Microsoft.DotNet.PlatformAbstractions": {
+    "listed": true,
+    "version": "3.1.0",
+    "analyzer": true
+  },
   "Microsoft.EntityFrameworkCore": {
     "listed": true,
     "version": "3.1.0"
@@ -444,10 +453,6 @@
     "listed": true,
     "version": "2.0.0"
   },
-  "Microsoft.Data.Sqlite.Core":{
-    "listed": true,
-    "version": "5.0.8"
-  },
   "Microsoft.NET.StringTools": {
     "listed": true,
     "version": "1.0.0"
@@ -478,7 +483,7 @@
     "listed": true,
     "version": "3.2.0"
   },
-  "NeoSmart.Caching.Sqlite":{
+  "NeoSmart.Caching.Sqlite": {
     "listed": true,
     "version": "5.0.2"
   },
@@ -608,21 +613,25 @@
     "version": "8.30.0.37606",
     "analyzer": true
   },
-  "SQLitePCLRaw.bundle_green":{
+  "SQLitePCLRaw.bundle_e_sqlite3": {
     "listed": true,
-    "version": "2.0.7"
+    "version": "2.0.2"
   },
-  "SQLitePCLRaw.core":{
+  "SQLitePCLRaw.bundle_green": {
     "listed": true,
-    "version": "2.0.4"
+    "version": "2.0.2"
   },
-  "SQLitePCLRaw.lib.e_sqlite3":{
+  "SQLitePCLRaw.core": {
     "listed": true,
-    "version": "2.0.7"
+    "version": "2.0.2"
   },
-  "SQLitePCLRaw.provider.e_sqlite3":{
+  "SQLitePCLRaw.lib.e_sqlite3": {
     "listed": true,
-    "version": "2.0.7"
+    "version": "2.0.2"
+  },
+  "SQLitePCLRaw.provider.e_sqlite3": {
+    "listed": true,
+    "version": "2.0.2"
   },
   "SSH.NET": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -236,6 +236,34 @@
   "Microsoft.CSharp": {
     "ignore": true
   },
+  "Microsoft.EntityFrameworkCore": {
+    "listed": false,
+    "version": "3.0.0"
+  },
+  "Microsoft.EntityFrameworkCore.Abstractions": {
+    "listed": false,
+    "version": "3.0.0"
+  },
+  "Microsoft.EntityFrameworkCore.Analyzers": {
+    "listed": false,
+    "version": "3.0.0"
+  },
+  "Microsoft.EntityFrameworkCore.Proxies": {
+    "listed": false,
+    "version": "3.0.0"
+  },
+  "Microsoft.EntityFrameworkCore.Relational": {
+    "listed": false,
+    "version": "3.0.0"
+  },
+  "Microsoft.EntityFrameworkCore.Sqlite": {
+    "listed": false,
+    "version": "3.0.0"
+  },
+  "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+    "listed": false,
+    "version": "3.0.0"
+  },
   "Microsoft.Extensions.Caching.Abstractions": {
     "listed": true,
     "version": "2.0.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package: 
> > - https://www.nuget.org/packages/Castle.Core/4.4.0
> > - https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.0
> > - https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Abstractions/3.1.0
> > - https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Analyzers/3.1.0
> > - https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Proxies/3.1.0
> > - https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Relational/3.1.0
> > - https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite/3.1.0
> > - https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Sqlite.Core/3.1.0
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


Hello @xoofx ,

## Understanding UnityNuGet
Should I just modify [registry.json](https://github.com/xoofx/UnityNuGet/blob/master/registry.json) ?

## Dependency issue
I am trying to upload EntityFrameworkCore to `UnityNuGet`. Had misunderstanding. Need your suggestion.
The [Microsoft.EntityFrameworkCore 3.1.25](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore/3.1.25) has [Microsoft.EntityFrameworkCore.Analyzers](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Analyzers/) in it's own dependencies list. But for some reason the dependency is optional, and for some reason, the dependency even doesn't work with Unity. Instead if to remove it manually that is fine. Standalone works pretty fine.