### PR TITLE
Fixes that the server cannot update dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -662,6 +662,9 @@
     "listed": true,
     "version": "4.4.0"
   },
+  "System.Security.Cryptography.X509Certificates": {
+    "ignore": true
+  },
   "System.Security.Cryptography.Xml": {
     "listed": true,
     "version": "4.4.0"


### PR DESCRIPTION
As of version 3.1.26 of Microsoft.Extensions.Configuration.Xml they have added a new dependency (System.Security.Cryptography.X509Certificates) and it causes everything to fail.

https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Xml/3.1.26

This dependency I have put it with "ignore: true" because it is a dependency that does not target netstandard2.0 but nothing happens because it is included in Unity.

I have tried to create a project, reference that package in that version and it works both in editor and player (win64).