### PR TITLE
Allow native-only packages

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -236,6 +236,10 @@
   "Microsoft.CSharp": {
     "ignore": true
   },
+  "Microsoft.Data.Sqlite.Core":{
+    "listed": true,
+    "version": "5.0.8"
+  },
   "Microsoft.Extensions.Caching.Abstractions": {
     "listed": true,
     "version": "2.0.0"
@@ -415,6 +419,10 @@
     "listed": true,
     "version": "3.2.0"
   },
+  "NeoSmart.Caching.Sqlite":{
+    "listed": true,
+    "version": "5.0.2"
+  },
   "Newtonsoft.Json": {
     "listed": true,
     "version": "11.0.1"
@@ -561,6 +569,22 @@
   "StrongInject.Extensions.DependencyInjection": {
     "listed": true,
     "version": "1.4.1"
+  },
+  "SQLitePCLRaw.bundle_green":{
+    "listed": true,
+    "version": "2.0.7"
+  },
+  "SQLitePCLRaw.core":{
+    "listed": true,
+    "version": "2.0.4"
+  },
+  "SQLitePCLRaw.lib.e_sqlite3":{
+    "listed": true,
+    "version": "2.0.7"
+  },
+  "SQLitePCLRaw.provider.e_sqlite3":{
+    "listed": true,
+    "version": "2.0.7"
   },
   "System.Buffers": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -549,6 +549,22 @@
     "version": "8.30.0.37606",
     "analyzer": true
   },
+  "SQLitePCLRaw.bundle_green":{
+    "listed": true,
+    "version": "2.0.7"
+  },
+  "SQLitePCLRaw.core":{
+    "listed": true,
+    "version": "2.0.4"
+  },
+  "SQLitePCLRaw.lib.e_sqlite3":{
+    "listed": true,
+    "version": "2.0.7"
+  },
+  "SQLitePCLRaw.provider.e_sqlite3":{
+    "listed": true,
+    "version": "2.0.7"
+  },
   "SSH.NET": {
     "listed": true,
     "version": "2020.0.0"
@@ -569,22 +585,6 @@
   "StrongInject.Extensions.DependencyInjection": {
     "listed": true,
     "version": "1.4.1"
-  },
-  "SQLitePCLRaw.bundle_green":{
-    "listed": true,
-    "version": "2.0.7"
-  },
-  "SQLitePCLRaw.core":{
-    "listed": true,
-    "version": "2.0.4"
-  },
-  "SQLitePCLRaw.lib.e_sqlite3":{
-    "listed": true,
-    "version": "2.0.7"
-  },
-  "SQLitePCLRaw.provider.e_sqlite3":{
-    "listed": true,
-    "version": "2.0.7"
   },
   "System.Buffers": {
     "listed": true,

--- a/src/UnityNuGet/UnityNuGet.csproj
+++ b/src/UnityNuGet/UnityNuGet.csproj
@@ -28,6 +28,7 @@
       <PackageReference Include="NUglify" Version="1.20.0" /> 
       <PackageReference Include="Scriban" Version="5.4.6" /> 
       <PackageReference Include="SharpZipLib" Version="1.3.3" /> 
-      <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+      <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" /> 
+      <PackageReference Include="System.Linq.Async" Version="6.0.1" /> 
     </ItemGroup>
 </Project>


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package:
>  - https://www.nuget.org/packages/Microsoft.Data.Sqlite.Core
>  - https://www.nuget.org/packages/NeoSmart.Caching.Sqlite
>  - https://www.nuget.org/packages/SQLitePCLRaw.bundle_green
>  - https://www.nuget.org/packages/SQLitePCLRaw.core
>  - https://www.nuget.org/packages/SQLitePCLRaw.lib.e_sqlite3
>  - https://www.nuget.org/packages/SQLitePCLRaw.provider.e_sqlite3
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

Closes #114 