### PR TITLE
Add LiteDB and LiteDB.Extensions.Caching

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -141,6 +141,14 @@
     "listed": true,
     "version": "1.0.2"
   },
+  "LiteDB": {
+    "listed": true,
+    "version": "5.0.12"
+  },
+  "LiteDb.Extensions.Caching": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "log4net": {
     "listed": true,
     "version": "2.0.11"

--- a/registry.json
+++ b/registry.json
@@ -143,7 +143,7 @@
   },
   "LiteDB": {
     "listed": true,
-    "version": "5.0.12"
+    "version": "5.0.1"
   },
   "LiteDb.Extensions.Caching": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package:
>  - https://www.nuget.org/packages/LiteDb.Extensions.Caching
>  - https://www.nuget.org/packages/LiteDB
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

The `5.0.1` version of `LiteDB` is the first version which has no dependencies on `netstandard2.0`, so it seem appropriate. Should also run on IL2CPP based on this: https://github.com/mbdavid/LiteDB/issues/1196#issuecomment-1096632704 using this [link.xml](https://gist.github.com/TigerHix/f270f2dc48222d17419bd46651926679)

Also added my package new project which implements `IDistributedCache` over LiteDB, so it can be used with Unity on all platforms.