### PR TITLE
Add NSubstitute, NSubstitute.Analyzers.CSharp and Castle.Core

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -709,6 +709,15 @@
     "listed": true,
     "version": "11.0.1"
   },
+  "NSubstitute": {
+    "listed": true,
+    "version": "4.4.0"
+  },
+  "NSubstitute.Analyzers.CSharp": {
+    "listed": true,
+    "version": "1.0.15",
+    "analyzer": true
+  },
   "NUnit.Analyzers": {
     "listed": true,
     "version": "[2.0.0,3.3.0]",

--- a/registry.json
+++ b/registry.json
@@ -711,7 +711,10 @@
   },
   "NSubstitute": {
     "listed": true,
-    "version": "4.4.0"
+    "version": "4.4.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
   },
   "NSubstitute.Analyzers.CSharp": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -711,7 +711,7 @@
   },
   "NSubstitute": {
     "listed": true,
-    "version": "4.4.0",
+    "version": "4.0.0",
     "defineConstraints": [
       "UNITY_EDITOR"
     ]


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package:
>     - https://www.nuget.org/packages/NSubstitute
>     - https://www.nuget.org/packages/NSubstitute.Analyzers.CSharp
>     - https://www.nuget.org/packages/Castle.Core
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


