### PR TITLE
Add Google.Cloud.Speech.V1

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -94,6 +94,10 @@
     "listed": true,
     "version": "1.44.0"
   },
+  "Google.Cloud.Speech.V1": {
+    "listed": true,
+    "version": "3.0.0"
+  },
   "Google.Protobuf": {
     "listed": true,
     "version": "3.8.0"

--- a/registry.json
+++ b/registry.json
@@ -96,7 +96,7 @@
   },
   "Google.Cloud.Speech.V1": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "1.2.0"
   },
   "Google.Protobuf": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -90,6 +90,10 @@
     "listed": true,
     "version": "2.7.0"
   },
+  "Google.Api.Gax.Grpc.GrpcCore": {
+    "listed": true,
+    "version": "3.0.0"
+  },
   "Google.Apis": {
     "listed": true,
     "version": "1.44.0"

--- a/registry.json
+++ b/registry.json
@@ -78,6 +78,18 @@
     "listed": true,
     "version": "2.0.0"
   },
+  "Google.Api.CommonProtos": {
+    "listed": true,
+    "version": "1.7.0"
+  },
+  "Google.Api.Gax": {
+    "listed": true,
+    "version": "2.7.0"
+  },
+  "Google.Api.Gax.Grpc": {
+    "listed": true,
+    "version": "2.7.0"
+  },
   "Google.Apis": {
     "listed": true,
     "version": "1.44.0"
@@ -98,9 +110,17 @@
     "listed": true,
     "version": "1.2.0"
   },
+  "Google.LongRunning": {
+    "listed": true,
+    "version": "2.0.0"
+  },
   "Google.Protobuf": {
     "listed": true,
     "version": "3.8.0"
+  },
+  "Grpc.Auth": {
+    "listed": true,
+    "version": "1.20.0"
   },
   "Grpc.Core": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Google.Cloud.Speech.V1
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [ ] The package has been tested with the Unity editor 
> - [ ] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


