### PR TITLE
Add CLSS (The C# Language Syntactic Sugar suite) packages

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -74,6 +74,10 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "CLSS.ExtensionMethods.IDictionary.RemoveAndProcess": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "CLSS.ExtensionMethods.IDictionary.SwapKeys": {
     "listed": true,
     "version": "1.1.0"
@@ -118,6 +122,10 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "CLSS.ExtensionMethods.IList.RemoveAndProcess": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "CLSS.ExtensionMethods.IList.Shuffle": {
     "listed": true,
     "version": "1.1.0"
@@ -140,13 +148,17 @@
   },
   "CLSS.ExtensionMethods.Pipe": {
     "listed": true,
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "CLSS.ExtensionMethods.Reference.Action.Once": {
     "listed": true,
     "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.String.AsEnum": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.AgnosticObjectPool": {
     "listed": true,
     "version": "1.0.0"
   },

--- a/registry.json
+++ b/registry.json
@@ -42,6 +42,138 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "CLSS.Constants.DefaultRandom": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "CLSS.Constants.NoOp": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Constants.ValueEquivalentStrings": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.CommonMathOps": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IComparable.ClampToRange": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IComparable.InRange": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "CLSS.ExtensionMethods.IDictionary.GetOrAdd": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IDictionary.MoveKey": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IDictionary.SwapKeys": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IEnumerable.ForEach": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IEnumerable.Looping": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IEnumerable.MinMaxBy": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IEnumerator.LoopNext": {
+    "listed": true,
+    "version": "1.0.1"
+  },
+  "CLSS.ExtensionMethods.IList.ExclusiveSample": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IList.FillBy": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IList.FirstLastIndex": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IList.GetLoopingElementAt": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.IList.GetRandom": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IList.GetWeightedRandom": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IList.Shuffle": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.IList.SwapIndices": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "CLSS.ExtensionMethods.Object.As": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.Object.Is": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.ExtensionMethods.Object.ToStringFormattedBy": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.Pipe": {
+    "listed": true,
+    "version": "1.2.0"
+  },
+  "CLSS.ExtensionMethods.Reference.Action.Once": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.ExtensionMethods.String.AsEnum": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.EventLatch": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.MemoizedFunc": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.Types.Reference": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.SortedAction": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "CLSS.Types.ValueRange": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "CLSS.Types.WeightedSampler": {
+    "listed": true,
+    "version": "1.1.0"
+  },
   "codecracker.CSharp": {
     "listed": true,
     "version": "1.1.0",


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package:
>   - https://www.nuget.org/packages/CLSS.Constants.DefaultRandom
>   - https://www.nuget.org/packages/CLSS.Constants.NoOp
>   - https://www.nuget.org/packages/CLSS.Constants.ValueEquivalentStrings
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.CommonMathOps
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IComparable.ClampToRange
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IComparable.InRange
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IDictionary.GetOrAdd
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IDictionary.MoveKey
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IDictionary.RemoveAndProcess
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IDictionary.SwapKeys
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IEnumerable.ForEach
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IEnumerable.Looping
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IEnumerable.MinMaxBy
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IEnumerator.LoopNext
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IList.ExclusiveSample
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IList.FillBy
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IList.FirstLastIndex
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IList.GetLoopingElementAt
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IList.GetRandom
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IList.GetWeightedRandom
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IList.RemoveAndProcess
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IList.Shuffle
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.IList.SwapIndices
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.Object.As
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.Object.Is
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.Object.ToStringFormattedBy
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.Pipe
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.Reference.Action.Once
>   - https://www.nuget.org/packages/CLSS.ExtensionMethods.String.AsEnum
>   - https://www.nuget.org/packages/CLSS.Types.AgnosticObjectPool
>   - https://www.nuget.org/packages/CLSS.Types.EventLatch
>   - https://www.nuget.org/packages/CLSS.Types.MemoizedFunc
>   - https://www.nuget.org/packages/CLSS.Types.Reference
>   - https://www.nuget.org/packages/CLSS.Types.SortedAction
>   - https://www.nuget.org/packages/CLSS.Types.ValueRange
>   - https://www.nuget.org/packages/CLSS.Types.WeightedSampler
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


