### PR TITLE
Add Magick.NET

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -165,6 +165,28 @@
     "listed": true,
     "version": "2.0.11"
   },
+  "Magick.NET.Core": {
+    "listed": true,
+    "version": "6.0.0"
+  },
+  "Magick.NET-Q8-AnyCPU": {
+    "listed": true,
+    "version": "7.23.0"
+  },
+  "Magick.NET-Q16-AnyCPU": 
+  {
+    "listed": true,
+    "version": "7.23.0"
+  },
+  "Magick.NET-Q8-x64": {
+    "listed": true,
+    "version": "7.23.0"
+  },
+  "Magick.NET-Q16-x64": 
+  {
+    "listed": true,
+    "version": "7.23.0"
+  },
   "MathNet.Numerics": {
     "listed": true,
     "version": "4.0.0"


### PR DESCRIPTION
While Magick.NET.Core is the managed-only base package, the other packages bring their native .dlls with them. Should be supported via https://github.com/xoofx/UnityNuGet/pull/91 -- let's see.

I've tested by using the Q8-AnyCPU -x64 packages and manually selecting the correct files and setting their .metas accordingly, so I guess the Q16 ones will be alright too.

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package:
  https://www.nuget.org/packages/Magick.NET.Core
   https://www.nuget.org/packages/Magick.NET-Q8-AnyCPU
  https://www.nuget.org/packages/Magick.NET-Q8-x64
  https://www.nuget.org/packages/Magick.NET-Q16-AnyCPU
  https://www.nuget.org/packages/Magick.NET-Q16-x64
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


