### PR TITLE
Add MongoDB.Driver, MongoDB.Driver.GrisFS and its dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -621,6 +621,10 @@
     "version": "16.3.13",
     "analyzer": true
   },
+  "MongoDB.Bson": {
+    "listed": true,
+    "version": "2.11.0"
+  },
   "MongoDB.Driver": {
     "listed": true,
     "version": "2.11.0"
@@ -630,10 +634,6 @@
     "version": "2.11.0"
   },
   "MongoDB.Driver.GridFS": {
-    "listed": true,
-    "version": "2.11.0"
-  },
-  "MongoDB.Bson": {
     "listed": true,
     "version": "2.11.0"
   },

--- a/registry.json
+++ b/registry.json
@@ -219,6 +219,10 @@
     "listed": true,
     "version": "1.0.0"
   },
+  "DnsClient": {
+    "listed": true,
+    "version": "1.3.1"
+  },
   "Eflatun.Expansions": {
     "listed": true,
     "version": "0.0.2"
@@ -616,6 +620,26 @@
     "listed": true,
     "version": "16.3.13",
     "analyzer": true
+  },
+  "MongoDB.Driver": {
+    "listed": true,
+    "version": "2.11.0"
+  },
+  "MongoDB.Driver.Core": {
+    "listed": true,
+    "version": "2.11.0"
+  },
+  "MongoDB.Driver.GridFS": {
+    "listed": true,
+    "version": "2.11.0"
+  },
+  "MongoDB.Bson": {
+    "listed": true,
+    "version": "2.11.0"
+  },
+  "MongoDB.Libmongocrypt": {
+    "listed": true,
+    "version": "1.0.0"
   },
   "Moq": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - Add a link to the NuGet package: https://www.nuget.org/packages/MongoDB.Driver/2.11.0
> - Add a link to the NuGet package: https://www.nuget.org/packages/MongoDB.Driver.GridFS/2.11.0
> - Dependency : https://www.nuget.org/packages/MongoDB.Driver.Core/2.11.0
> - Dependency : https://www.nuget.org/packages/MongoDB.Libmongocrypt/1.0.0
> - Dependency : https://www.nuget.org/packages/DnsClient/1.3.1
> - Dependency : https://www.nuget.org/packages/MongoDB.Bson/2.11.0
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.