### PR TITLE
Add JsonSubTypes package

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -305,6 +305,10 @@
     "listed": true,
     "version": "2.2.0"
   },
+  "JsonSubTypes": {
+    "listed": true,
+    "version": "1.4.0"
+  },
   "K4os.Compression.LZ4": {
     "listed": true,
     "version": "1.0.2"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package: https://www.nuget.org/packages/JsonSubTypes
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


