### PR TITLE
Fix problems in multiple packages

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "Asmodat.Standard.SSH.NET": {
     "listed": true,
-    "version": "(,1.0.0.1]"
+    "version": "[1.0.0,1.0.0.1]"
   },
   "AutoMapper": {
     "listed": true,
@@ -239,7 +239,7 @@
   },
   "GeneticSharp": {
     "listed": true,
-    "version": "2.0.0"
+    "version": "[2.0.0,3.0.0)"
   },
   "Google.Apis": {
     "listed": true,
@@ -578,7 +578,7 @@
   },
   "Microsoft.NET.StringTools": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "[1.0.0]"
   },
   "Microsoft.Toolkit.Mvvm": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -168,7 +168,7 @@
   },
   "CLSS.Types.MemoizedFunc": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "CLSS.Types.Reference": {
     "listed": true,


### PR DESCRIPTION
Minor fixes:

- Set the minimum version in the range for Asmodat.Standard.SSH.NET. It doesn't matter because the minimum version (1.0.0) was already compatible with .NET Standard 2.0 but just in case it is set in the range.

Warning fixes:

- Set a range for GeneticSharp of < 3.0.0 since as of [that version](https://www.nuget.org/packages/GeneticSharp/3.0.0) it only targets .NET 6.0.

- Bump the minimum CLSS.Types.MemoizedFunc package version because right now it depends unnecessarily on System.ValueTuple and causes a warning.

**Error fixes (this causes the registry to stop updating packages)**:

- Set the single version of Microsoft.NET.StringTools to 1.0.0 because from the next version (17.3.0) it must have something wrong in the metadata that makes it not have the .NET Standard 2.0 framework even though [on the page it appears](https://www.nuget.org/packages/Microsoft.NET.StringTools/17.3.1). Right now this dependency is only used as of [MessagePack 2.4.x](https://www.nuget.org/packages/MessagePack/2.4.35#dependencies-body-tab) with >= 1.0.0 so there shouldn't be any problems. The only collateral damage is that it causes a warning that we cannot remove.

![image](https://user-images.githubusercontent.com/950602/193815927-7e736481-c267-4da4-a66d-3c48370e6a9f.png)

VS:

Code from: https://github.com/xoofx/UnityNuGet/blob/master/src/UnityNuGet/RegistryCache.cs#L458

More info:

https://github.com/dotnet/msbuild/blob/v17.3.1/src/Directory.Build.props#L33
https://github.com/dotnet/msbuild/blob/v17.3.1/src/StringTools/StringTools.csproj

![image](https://user-images.githubusercontent.com/950602/193815771-fc62221d-50f2-4b0a-9976-3e00295600c9.png)