### PR TITLE
Fix dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '7.0.x'
 
     - name: Build & test (Release)
       run: dotnet test src -c Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0.100 AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 WORKDIR /app
 
 RUN mkdir -p src/UnityNuGet && mkdir -p src/UnityNuGet.Server && mkdir -p src/UnityNuGet.Tests
@@ -13,7 +13,7 @@ COPY . ./
 RUN dotnet publish src -c Release -o /app/src/out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:7.0
 WORKDIR /app
 COPY --from=build /app/src/out .
 ENTRYPOINT ["dotnet", "UnityNuGet.Server.dll"]

--- a/registry.json
+++ b/registry.json
@@ -243,7 +243,7 @@
   },
   "FluentAssertions": {
     "listed": true,
-    "version": "5.0.0",
+    "version": "5.4.0",
     "defineConstraints": [
       "UNITY_EDITOR"
     ]
@@ -318,7 +318,7 @@
   },
   "JsonSubTypes": {
     "listed": true,
-    "version": "1.4.0"
+    "version": "2.0.0"
   },
   "K4os.Compression.LZ4": {
     "listed": true,
@@ -438,31 +438,31 @@
   },
   "Microsoft.EntityFrameworkCore": {
     "listed": true,
-    "version": "3.1.0"
+    "version": "[3.1.0,6.0.0)"
   },
   "Microsoft.EntityFrameworkCore.Abstractions": {
     "listed": true,
-    "version": "3.1.0"
+    "version": "[3.1.0,6.0.0)"
   },
   "Microsoft.EntityFrameworkCore.Analyzers": {
     "listed": true,
-    "version": "3.1.0"
+    "version": "[3.1.0,6.0.0)"
   },
   "Microsoft.EntityFrameworkCore.Proxies": {
     "listed": true,
-    "version": "3.1.0"
+    "version": "[3.1.0,6.0.0)"
   },
   "Microsoft.EntityFrameworkCore.Relational": {
     "listed": true,
-    "version": "3.1.0"
+    "version": "[3.1.0,6.0.0)"
   },
   "Microsoft.EntityFrameworkCore.Sqlite": {
     "listed": true,
-    "version": "3.1.0"
+    "version": "[3.1.0,6.0.0)"
   },
   "Microsoft.EntityFrameworkCore.Sqlite.Core": {
     "listed": true,
-    "version": "3.1.0"
+    "version": "[3.1.0,6.0.0)"
   },
   "Microsoft.Extensions.Caching.Abstractions": {
     "listed": true,
@@ -643,25 +643,29 @@
     "version": "16.3.13",
     "analyzer": true
   },
+  "Microsoft.Win32.Registry": {
+    "listed": true,
+    "version": "4.4.0"
+  },
   "MongoDB.Bson": {
     "listed": true,
-    "version": "2.11.0"
+    "version": "2.12.0"
   },
   "MongoDB.Driver": {
     "listed": true,
-    "version": "2.11.0"
+    "version": "2.12.0"
   },
   "MongoDB.Driver.Core": {
     "listed": true,
-    "version": "2.11.0"
+    "version": "2.12.0"
   },
   "MongoDB.Driver.GridFS": {
     "listed": true,
-    "version": "2.11.0"
+    "version": "2.12.0"
   },
   "MongoDB.Libmongocrypt": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.2.0"
   },
   "Moq": {
     "listed": true,
@@ -787,9 +791,9 @@
     "listed": true,
     "version": "3.0.0"
   },
-  "Sharpcompress": {
+  "SharpCompress": {
     "listed": true,
-    "version": "0.24.0"
+    "version": "0.22.0"
   },
   "SharpYaml": {
     "listed": true,
@@ -800,6 +804,10 @@
     "version": "1.0.0"
   },
   "SixLabors.ImageSharp": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Snappier": {
     "listed": true,
     "version": "1.0.0"
   },
@@ -1036,5 +1044,9 @@
   "VoltRpc.Extension.Vectors": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "ZstdSharp.Port": {
+    "listed": true,
+    "version": "0.1.0"
   }
 }

--- a/src/UnityNuGet.Server/EndpointRouteBuilderExtensions.cs
+++ b/src/UnityNuGet.Server/EndpointRouteBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Scriban;

--- a/src/UnityNuGet.Server/RegistryCacheInitializer.cs
+++ b/src/UnityNuGet.Server/RegistryCacheInitializer.cs
@@ -40,7 +40,7 @@ namespace UnityNuGet.Server
                 var urls = configuration[WebHostDefaults.ServerUrlsKey];
 
                 // Select HTTPS in production, HTTP in development
-                var url = urls.Split(';').FirstOrDefault(x => !x.StartsWith("https"));
+                var url = urls?.Split(';').FirstOrDefault(x => !x.StartsWith("https"));
                 if (url == null)
                 {
                     throw new InvalidOperationException($"Unable to find a proper server URL from `{urls}`. Expecting a `http://...` URL in development");

--- a/src/UnityNuGet.Server/UnityNuGet.Server.csproj
+++ b/src/UnityNuGet.Server/UnityNuGet.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ApplicationInsightsResourceId>/subscriptions/b6745039-70e7-4641-994b-5457cb220e2a/resourcegroups/Default-ApplicationInsights-EastUS/providers/microsoft.insights/components/unitynuget-registry</ApplicationInsightsResourceId>
         <ApplicationInsightsAnnotationResourceId>/subscriptions/b6745039-70e7-4641-994b-5457cb220e2a/resourcegroups/Default-ApplicationInsights-EastUS/providers/microsoft.insights/components/unitynuget-registry</ApplicationInsightsAnnotationResourceId>
@@ -16,10 +16,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.8" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
-        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.16.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" />
+        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UnityNuGet.Tests/UnityNuGet.Tests.csproj
+++ b/src/UnityNuGet.Tests/UnityNuGet.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="nunit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UnityNuGet.sln
+++ b/src/UnityNuGet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29728.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33103.184
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UnityNuGet.Server", "UnityNuGet.Server\UnityNuGet.Server.csproj", "{C84FC40C-94EE-4314-BB48-CD1A98849D82}"
 EndProject

--- a/src/UnityNuGet/UnityNuGet.csproj
+++ b/src/UnityNuGet/UnityNuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <Version>0.14.0</Version>
         <LangVersion>9.0</LangVersion>
@@ -22,13 +22,14 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-      <PackageReference Include="NuGet.PackageManagement" Version="6.3.0" />
-      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" /> 
+      <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
+      <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" /> 
       <PackageReference Include="NUglify" Version="1.20.2" /> 
       <PackageReference Include="Scriban" Version="5.5.0" /> 
-      <PackageReference Include="SharpZipLib" Version="1.3.3" /> 
+      <PackageReference Include="SharpZipLib" Version="1.4.1" /> 
       <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" /> 
       <PackageReference Include="System.Linq.Async" Version="6.0.1" /> 
     </ItemGroup>
+
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.100",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
- Add missing dependencies
- Lift version of certain dependencies for indirectly relying on dependencies that do not target .NET Standard 2.0
- Limit Microsoft.EntityFrameworkCore.* to < 6.0.0 since it only targets .NET 6+ from then on.
- Fix dependency name because of case sensitive issues