### PR TITLE
Add NUnit.Analyzers

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -682,6 +682,11 @@
     "listed": true,
     "version": "11.0.1"
   },
+  "NUnit.Analyzers": {
+    "listed": true,
+    "version": "[2.0.0,3.3.0]",
+    "analyzer": true
+  },
   "Polly": {
     "listed": true,
     "version": "6.0.1"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/NUnit.Analyzers
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
>   - **Not applicable, it is an analyzer**
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
>   - **Not applicable, it is an analyzer**
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


Reason for version range:

- NUnit.Analyzers v2.x was built with Microsoft.CodeAnalysis.CSharp 2.10.0, it works on Unity under 2021.2
- NUnit.Analyzers v3.0-3.3 was built with Microsoft.CodeAnalysis.CSharp 3.8.0, it works on Unity 2021.2 or later
- NUnit.Analyzers v3.4 or later was built with Microsoft.CodeAnalysis.CSharp 3.11.0, it does not work on Unity