### PR TITLE
Update CLSS packages to Update 8

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -56,51 +56,51 @@
   },
   "CLSS.Constants.DefaultRandom": {
     "listed": true,
-    "version": "1.2.1"
+    "version": "1.2.0"
   },
   "CLSS.Constants.NoOp": {
     "listed": true,
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "CLSS.Constants.ValueEquivalentStrings": {
     "listed": true,
-    "version": "1.1.1"
+    "version": "1.1.0"
   },
   "CLSS.ExtensionMethods.CommonMathOps": {
     "listed": true,
-    "version": "1.1.1"
+    "version": "1.1.0"
   },
   "CLSS.ExtensionMethods.IComparable.ClampToRange": {
     "listed": true,
-    "version": "1.2.0"
+    "version": "1.1.0"
   },
   "CLSS.ExtensionMethods.IComparable.InRange": {
     "listed": true,
-    "version": "1.3.0"
+    "version": "1.2.0"
   },
   "CLSS.ExtensionMethods.IDictionary.GetOrAdd": {
     "listed": true,
-    "version": "1.1.1"
+    "version": "1.1.0"
   },
   "CLSS.ExtensionMethods.IDictionary.MoveKey": {
     "listed": true,
-    "version": "1.1.1"
+    "version": "1.1.0"
   },
   "CLSS.ExtensionMethods.IDictionary.RemoveAndProcess": {
     "listed": true,
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IDictionary.SwapKeys": {
     "listed": true,
-    "version": "1.1.1"
+    "version": "1.1.0"
   },
   "CLSS.ExtensionMethods.IEnumerable.ForEach": {
     "listed": true,
-    "version": "1.1.1"
+    "version": "1.1.0"
   },
   "CLSS.ExtensionMethods.IEnumerable.Looping": {
     "listed": true,
-    "version": "1.1.1"
+    "version": "1.1.0"
   },
   "CLSS.ExtensionMethods.IEnumerable.MinMaxBy": {
     "listed": true,
@@ -136,7 +136,7 @@
   },
   "CLSS.ExtensionMethods.IList.RemoveAndProcess": {
     "listed": true,
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IList.Shuffle": {
     "listed": true,
@@ -168,11 +168,11 @@
   },
   "CLSS.ExtensionMethods.String.AsEnum": {
     "listed": true,
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "CLSS.Types.AgnosticObjectPool": {
     "listed": true,
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "CLSS.Types.EventLatch": {
     "listed": true,
@@ -192,7 +192,7 @@
   },
   "CLSS.Types.ValueRange": {
     "listed": true,
-    "version": "1.0.1"
+    "version": "1.0.0"
   },
   "CLSS.Types.WeightedSampler": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -50,53 +50,57 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "CLSS.Constants.CollectionPool": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "CLSS.Constants.DefaultRandom": {
     "listed": true,
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "CLSS.Constants.NoOp": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "CLSS.Constants.ValueEquivalentStrings": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "CLSS.ExtensionMethods.CommonMathOps": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "CLSS.ExtensionMethods.IComparable.ClampToRange": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "CLSS.ExtensionMethods.IComparable.InRange": {
     "listed": true,
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "CLSS.ExtensionMethods.IDictionary.GetOrAdd": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "CLSS.ExtensionMethods.IDictionary.MoveKey": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "CLSS.ExtensionMethods.IDictionary.RemoveAndProcess": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "CLSS.ExtensionMethods.IDictionary.SwapKeys": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "CLSS.ExtensionMethods.IEnumerable.ForEach": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "CLSS.ExtensionMethods.IEnumerable.Looping": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.1.1"
   },
   "CLSS.ExtensionMethods.IEnumerable.MinMaxBy": {
     "listed": true,
@@ -132,7 +136,7 @@
   },
   "CLSS.ExtensionMethods.IList.RemoveAndProcess": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "CLSS.ExtensionMethods.IList.Shuffle": {
     "listed": true,
@@ -164,11 +168,11 @@
   },
   "CLSS.ExtensionMethods.String.AsEnum": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "CLSS.Types.AgnosticObjectPool": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "CLSS.Types.EventLatch": {
     "listed": true,
@@ -188,7 +192,7 @@
   },
   "CLSS.Types.ValueRange": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "CLSS.Types.WeightedSampler": {
     "listed": true,


### PR DESCRIPTION
This PR is intended to bring the uplinked CLSS packages to par with [Update 8](https://github.com/tonygiang/CLSS/blob/main/CHANGELOG.md).

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package:
>   - https://www.nuget.org/packages/CLSS.Constants.CollectionPool
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


