### PR TITLE
Improvements (Mostly "binding redirects")

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,10 @@ This project provides a seamlessly integration of a [curated list](registry.json
 
 > DISCLAIMER: This is not an official service provided by Unity Technologies Inc.
 
+## Installation
+
+### Add scope registry (manifest.json):
+
 In order to use this service you simply need to edit the `Packages/manifest.json` in your project and add the following scoped registry:
 
 ```json
@@ -25,10 +29,28 @@ In order to use this service you simply need to edit the `Packages/manifest.json
 }
 ```
 
+### Add scope registry (Package Manager UI):
+
+Instructions: https://docs.unity3d.com/Manual/class-PackageManager.html
+
+```
+Name: Unity NuGet
+
+Url: https://unitynuget-registry.azurewebsites.net
+
+Scope(s): org.nuget
+```
+
+### Disable Assembly Version Validation
+
+Uncheck: "Project Settings > Player > Other Settings > Configuration > Assembly Version Validation"
+
 > WARNING: If you are encountering weird compilation errors with UnityNuGet and you have been using UnityNuGet already, 
 > it could be that we have updated packages on the server, and in that case, you need to clear the cache containing
 > all Unity NPM packages downdloaded from the `unitynuget-registry.azurewebsites.net` registry.
 > On Windows, this cache is located at: `%localappdata%\Unity\cache\npm\unitynuget-registry.azurewebsites.net`
+>
+> Cache locations by OS: https://docs.unity3d.com/Manual/upm-cache.html
 
 When opening the Package Manager Window, you should see a few packages coming from NuGet (with the postfix text ` (NuGet)`)
 
@@ -45,13 +67,14 @@ Your NuGet package needs to respect a few constraints in order to be listed in t
 
 You can send a PR to this repository to modify the [registry.json](registry.json) file (don't forget to maintain the alphabetical order)
 
-I recommend also to **specify the lowest version of your package that has support for `.NETStandard2.0`** upward so that other packages depending on your package have a chance to work with.
+You also need to **specify the lowest version of your package that has support for `.NETStandard2.0`** upward so that other packages depending on your package have a chance to work with.
 
 Beware that **all transitive dependencies of the package** must be **explicitly listed** in the registry as well.
 
 > NOTE: 
 > * We reserve the right to decline a package to be available through this service
 > * The server will be updated only when a new version tag is pushed on the main branch.
+
 ## Compatibility
 
 Only compatible with **`Unity 2019.1`** and potentially with newer version.
@@ -99,27 +122,29 @@ To add a private feed, the following fields must be filled in.
 </configuration>
 ```
 
-**Note**: The Azure DevOps PAT must have Packaging (Read) permissions.
+**Note**: [The Azure DevOps PAT](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate) must have Packaging (Read) permissions.
 
 ## FAQ
 
-### Where is hosted this service?
+### **Where is hosted this service?**
 
 On Azure through my own Azure credits coming from my MVP subscription, enjoy!
 
-### Why can't you add all NuGet packages?
+### **Why can't you add all NuGet packages?**
 
 The reason is that many NuGet packages are not compatible with Unity, or do not provide .NETStandard2.0 assemblies or are not relevant for being used within Unity.
 
 Also currently the Package Manager doesn't provide a way to filter easily packages, so the UI is currently not adequate to list lots of packages.
 
-### Why does it require .NETStandard2.0?
+### **Why does it require .NETStandard2.0?**
 
 Since 2019.1, Unity is now compatible with `.NETStandard2.0` and it is the .NET profile that is preferred to be used
 
 Having a `.NETStandard2.0` for NuGet packages for Unity can ensure that the experience to add a package to your project is consistent and well supported.
 
-### How this service is working?
+More information: https://docs.unity3d.com/Manual/dotnetProfileSupport.html
+
+### **How this service is working?**
 
 This project implements a simplified compatible NPM server in C# using ASP.NET Core and converts NuGet packages to Unity packages before serving them. 
 

--- a/registry.json
+++ b/registry.json
@@ -969,9 +969,6 @@
     "listed": true,
     "version": "4.4.0"
   },
-  "System.Security.Cryptography.X509Certificates": {
-    "ignore": true
-  },
   "System.Security.Cryptography.Xml": {
     "listed": true,
     "version": "4.4.0"

--- a/registry.json
+++ b/registry.json
@@ -9,31 +9,31 @@
   },
   "AsyncAwaitBestPractices.MVVM": {
     "listed": true,
-    "version": "4.0.1"
+    "version": "5.0.2"
   },
   "AutoMapper": {
     "listed": true,
-    "version": "10.0.0"
+    "version": "7.0.1"
   },
   "AutoMapper.Extensions.Microsoft.DependencyInjection": {
     "listed": true,
-    "version": "8.0.0"
+    "version": "3.0.1"
   },
   "AutomaticGraphLayout": {
     "listed": true,
-    "version": "1.1.6"
+    "version": "1.1.4.3"
   },
   "AWSSDK.Core": {
     "listed": true,
-    "version": "3.5.0"
+    "version": "3.3.100"
   },
   "AWSSDK.S3": {
     "listed": true,
-    "version": "3.5.0"
+    "version": "3.3.100"
   },
   "Ben.Demystifier": {
     "listed": true,
-    "version": "0.1.6"
+    "version": "0.0.43"
   },
   "BugSplatDotNetStandard": {
     "listed": true,
@@ -41,18 +41,18 @@
   },
   "Castle.Core": {
     "listed": true,
-    "version": "4.4.0",
+    "version": "5.0.0",
     "defineConstraints": [
       "UNITY_EDITOR"
     ]
   },
   "CircularBuffer": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.2"
   },
   "CLSS.Constants.DefaultRandom": {
     "listed": true,
-    "version": "1.2.0"
+    "version": "1.0.0"
   },
   "CLSS.Constants.NoOp": {
     "listed": true,
@@ -60,27 +60,27 @@
   },
   "CLSS.Constants.ValueEquivalentStrings": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.CommonMathOps": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IComparable.ClampToRange": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IComparable.InRange": {
     "listed": true,
-    "version": "1.2.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IDictionary.GetOrAdd": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IDictionary.MoveKey": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IDictionary.RemoveAndProcess": {
     "listed": true,
@@ -88,15 +88,15 @@
   },
   "CLSS.ExtensionMethods.IDictionary.SwapKeys": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IEnumerable.ForEach": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IEnumerable.Looping": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IEnumerable.MinMaxBy": {
     "listed": true,
@@ -108,15 +108,15 @@
   },
   "CLSS.ExtensionMethods.IList.ExclusiveSample": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IList.FillBy": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IList.FirstLastIndex": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IList.GetLoopingElementAt": {
     "listed": true,
@@ -124,11 +124,11 @@
   },
   "CLSS.ExtensionMethods.IList.GetRandom": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IList.GetWeightedRandom": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IList.RemoveAndProcess": {
     "listed": true,
@@ -136,11 +136,11 @@
   },
   "CLSS.ExtensionMethods.IList.Shuffle": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.IList.SwapIndices": {
     "listed": true,
-    "version": "1.2.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.Object.As": {
     "listed": true,
@@ -148,7 +148,7 @@
   },
   "CLSS.ExtensionMethods.Object.Is": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.Object.ToStringFormattedBy": {
     "listed": true,
@@ -156,7 +156,7 @@
   },
   "CLSS.ExtensionMethods.Pipe": {
     "listed": true,
-    "version": "1.3.0"
+    "version": "1.0.0"
   },
   "CLSS.ExtensionMethods.Reference.Action.Once": {
     "listed": true,
@@ -176,7 +176,7 @@
   },
   "CLSS.Types.MemoizedFunc": {
     "listed": true,
-    "version": "1.2.0"
+    "version": "1.0.0"
   },
   "CLSS.Types.Reference": {
     "listed": true,
@@ -184,7 +184,7 @@
   },
   "CLSS.Types.SortedAction": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "CLSS.Types.ValueRange": {
     "listed": true,
@@ -192,7 +192,7 @@
   },
   "CLSS.Types.WeightedSampler": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "1.0.0"
   },
   "codecracker.CSharp": {
     "listed": true,
@@ -229,11 +229,11 @@
   },
   "DnsClient": {
     "listed": true,
-    "version": "1.3.1"
+    "version": "1.1.0"
   },
   "Eflatun.Expansions": {
     "listed": true,
-    "version": "0.0.2"
+    "version": "0.0.1"
   },
   "ErrorProne.NET.CoreAnalyzers": {
     "listed": true,
@@ -251,7 +251,7 @@
   },
   "FluentAssertions": {
     "listed": true,
-    "version": "5.4.0",
+    "version": "5.0.0",
     "defineConstraints": [
       "UNITY_EDITOR"
     ]
@@ -262,19 +262,19 @@
   },
   "Google.Apis": {
     "listed": true,
-    "version": "1.44.0"
+    "version": "1.35.0"
   },
   "Google.Apis.AndroidPublisher.v3": {
     "listed": true,
-    "version": "1.44.0.1872"
+    "version": "1.35.1.1312"
   },
   "Google.Apis.Auth": {
     "listed": true,
-    "version": "1.44.0"
+    "version": "1.35.0"
   },
   "Google.Apis.Core": {
     "listed": true,
-    "version": "1.44.0"
+    "version": "1.35.0"
   },
   "Google.Protobuf": {
     "listed": true,
@@ -326,7 +326,7 @@
   },
   "JsonSubTypes": {
     "listed": true,
-    "version": "2.0.0"
+    "version": "1.4.0"
   },
   "K4os.Compression.LZ4": {
     "listed": true,
@@ -334,7 +334,7 @@
   },
   "LiteDB": {
     "listed": true,
-    "version": "5.0.1"
+    "version": "4.0.0"
   },
   "LiteDb.Extensions.Caching": {
     "listed": true,
@@ -342,7 +342,7 @@
   },
   "log4net": {
     "listed": true,
-    "version": "2.0.11"
+    "version": "2.0.9"
   },
   "MathNet.Numerics": {
     "listed": true,
@@ -350,15 +350,15 @@
   },
   "McMaster.Extensions.CommandLineUtils": {
     "listed": true,
-    "version": "2.2.0"
+    "version": "2.0.0"
   },
   "MessagePack": {
     "listed": true,
-    "version": "2.1.80"
+    "version": "1.7.0"
   },
   "MessagePack.Annotations": {
     "listed": true,
-    "version": "2.1.80"
+    "version": "2.0.323"
   },
   "Meziantou.Analyzer": {
     "listed": true,
@@ -399,7 +399,7 @@
   },
   "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": {
     "listed": true,
-    "version": "5.0.0"
+    "version": "1.0.0"
   },
   "Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson": {
     "listed": true,
@@ -437,7 +437,7 @@
   },
   "Microsoft.Data.Sqlite.Core": {
     "listed": true,
-    "version": "3.1.0"
+    "version": "2.0.0"
   },
   "Microsoft.DotNet.PlatformAbstractions": {
     "listed": true,
@@ -510,7 +510,7 @@
   },
   "Microsoft.Extensions.Configuration.Json": {
     "listed": true,
-    "version": "2.1.0"
+    "version": "2.0.0"
   },
   "Microsoft.Extensions.Configuration.NewtonsoftJson": {
     "listed": true,
@@ -518,7 +518,7 @@
   },
   "Microsoft.Extensions.Configuration.UserSecrets": {
     "listed": true,
-    "version": "2.1.0"
+    "version": "2.0.0"
   },
   "Microsoft.Extensions.Configuration.Xml": {
     "listed": true,
@@ -558,7 +558,7 @@
   },
   "Microsoft.Extensions.Hosting": {
     "listed": true,
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "Microsoft.Extensions.Hosting.Abstractions": {
     "listed": true,
@@ -602,11 +602,11 @@
   },
   "Microsoft.Extensions.Logging.EventSource": {
     "listed": true,
-    "version": "2.1.0"
+    "version": "2.0.0"
   },
   "Microsoft.Extensions.Logging.Log4Net.AspNetCore": {
     "listed": true,
-    "version": "5.0.3"
+    "version": "2.0.1"
   },
   "Microsoft.Extensions.Logging.TraceSource": {
     "listed": true,
@@ -636,6 +636,9 @@
     "listed": true,
     "version": "[1.0.0]"
   },
+  "Microsoft.NETCore.Platforms": {
+    "ignore": true
+  },
   "Microsoft.Toolkit.Mvvm": {
     "listed": true,
     "version": "7.0.0",
@@ -657,19 +660,19 @@
   },
   "MongoDB.Bson": {
     "listed": true,
-    "version": "2.12.0"
+    "version": "2.11.0"
   },
   "MongoDB.Driver": {
     "listed": true,
-    "version": "2.12.0"
+    "version": "2.11.0"
   },
   "MongoDB.Driver.Core": {
     "listed": true,
-    "version": "2.12.0"
+    "version": "2.11.0"
   },
   "MongoDB.Driver.GridFS": {
     "listed": true,
-    "version": "2.12.0"
+    "version": "2.11.0"
   },
   "MongoDB.Libmongocrypt": {
     "listed": true,
@@ -677,18 +680,18 @@
   },
   "Moq": {
     "listed": true,
-    "version": "4.18.0",
+    "version": "4.11.0",
     "defineConstraints": [
       "UNITY_EDITOR"
     ]
   },
   "morelinq": {
     "listed": true,
-    "version": "3.2.0"
+    "version": "2.7.0"
   },
   "NeoSmart.Caching.Sqlite": {
     "listed": true,
-    "version": "5.0.2"
+    "version": "0.1.0"
   },
   "Newtonsoft.Json": {
     "listed": true,
@@ -708,7 +711,7 @@
   },
   "protobuf-net": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "2.3.6"
   },
   "protobuf-net.Core": {
     "listed": true,
@@ -716,11 +719,11 @@
   },
   "QuikGraph": {
     "listed": true,
-    "version": "2.0.0"
+    "version": "1.0.0"
   },
   "RestSharp": {
     "listed": true,
-    "version": "106.2.2"
+    "version": "106.0.0"
   },
   "RestSharp.Serializers.NewtonsoftJson": {
     "listed": true,
@@ -732,11 +735,11 @@
   },
   "Rhino3dm": {
     "listed": true,
-    "version": "7.6.0"
+    "version": "0.1.0"
   },
   "Robots": {
     "listed": true,
-    "version": "1.1.5"
+    "version": "1.1.7"
   },
   "Roslynator.Analyzers": {
     "listed": true,
@@ -745,19 +748,19 @@
   },
   "Scriban": {
     "listed": true,
-    "version": "2.1.0"
+    "version": "1.2.4"
   },
   "Scrutor": {
     "listed": true,
-    "version": "4.1.0"
+    "version": "3.0.1"
   },
   "Serialization.NET": {
     "listed": true,
-    "version": "0.1.0"
+    "version": "1.0.0"
   },
   "Serilog": {
     "listed": true,
-    "version": "2.9.0"
+    "version": "2.8.0"
   },
   "Serilog.Enrichers.Demystifier": {
     "listed": true,
@@ -765,19 +768,19 @@
   },
   "Serilog.Extensions.Hosting": {
     "listed": true,
-    "version": "4.2.0"
+    "version": "2.0.0"
   },
   "Serilog.Extensions.Logging": {
     "listed": true,
-    "version": "3.1.0"
+    "version": "2.0.0"
   },
   "Serilog.Settings.Configuration": {
     "listed": true,
-    "version": "3.2.0"
+    "version": "3.0.0"
   },
   "Serilog.Sinks.Async": {
     "listed": true,
-    "version": "1.5.0"
+    "version": "1.4.0"
   },
   "Serilog.Sinks.Console": {
     "listed": true,
@@ -785,15 +788,15 @@
   },
   "Serilog.Sinks.Debug": {
     "listed": true,
-    "version": "2.0.0"
+    "version": "1.0.1"
   },
   "Serilog.Sinks.File": {
     "listed": true,
-    "version": "5.0.0"
+    "version": "4.1.0"
   },
   "Serilog.Sinks.Graylog": {
     "listed": true,
-    "version": "2.3.0"
+    "version": "1.1.89"
   },
   "Serilog.Sinks.Trace": {
     "listed": true,
@@ -801,11 +804,11 @@
   },
   "SharpCompress": {
     "listed": true,
-    "version": "0.22.0"
+    "version": "0.19.0"
   },
   "SharpYaml": {
     "listed": true,
-    "version": "1.8.0"
+    "version": "1.6.4"
   },
   "SharpZipLib": {
     "listed": true,
@@ -830,23 +833,23 @@
   },
   "SQLitePCLRaw.bundle_e_sqlite3": {
     "listed": true,
-    "version": "2.0.2"
+    "version": "2.0.0"
   },
   "SQLitePCLRaw.bundle_green": {
     "listed": true,
-    "version": "2.0.2"
+    "version": "2.0.0"
   },
   "SQLitePCLRaw.core": {
     "listed": true,
-    "version": "2.0.2"
+    "version": "2.0.0"
   },
   "SQLitePCLRaw.lib.e_sqlite3": {
     "listed": true,
-    "version": "2.0.2"
+    "version": "2.0.0"
   },
   "SQLitePCLRaw.provider.e_sqlite3": {
     "listed": true,
-    "version": "2.0.2"
+    "version": "2.1.0"
   },
   "SSH.NET": {
     "listed": true,
@@ -983,11 +986,11 @@
   },
   "System.ServiceModel.Primitives": {
     "listed": true,
-    "version": "4.6.0"
+    "version": "4.4.0"
   },
   "System.Text.Encoding.CodePages": {
     "listed": false,
-    "version": "4.5.0"
+    "version": "4.4.0"
   },
   "System.Text.Encodings.Web": {
     "listed": true,
@@ -1020,19 +1023,19 @@
   },
   "UnitsNet": {
     "listed": true,
-    "version": "4.101.0"
+    "version": "4.0.0"
   },
   "UnitsNet.NumberExtensions": {
     "listed": true,
-    "version": "4.101.0"
+    "version": "4.44.0"
   },
   "UnitsNet.Serialization.JsonNet": {
     "listed": true,
-    "version": "4.5.0"
+    "version": "4.0.0"
   },
   "Validation": {
     "listed": true,
-    "version": "2.5.51"
+    "version": "2.5.42"
   },
   "VoltRpc": {
     "listed": true,
@@ -1052,6 +1055,6 @@
   },
   "ZstdSharp.Port": {
     "listed": true,
-    "version": "0.1.0"
+    "version": "0.5.0"
   }
 }

--- a/src/UnityNuGet.Server/UnityNuGet.Server.csproj
+++ b/src/UnityNuGet.Server/UnityNuGet.Server.csproj
@@ -16,7 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.1" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="7.0.0" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />

--- a/src/UnityNuGet.Tests/NuGetHelperTests.cs
+++ b/src/UnityNuGet.Tests/NuGetHelperTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NUnit.Framework;
+using static NuGet.Frameworks.FrameworkConstants;
+
+namespace UnityNuGet.Tests
+{
+    public class NuGetHelperTests
+    {
+        [Test]
+        public void GetCompatiblePackageDependencyGroups_SpecificSingleFramework()
+        {
+            IList<PackageDependencyGroup> packageDependencyGroups = new PackageDependencyGroup[]
+            {
+                new PackageDependencyGroup(CommonFrameworks.NetStandard13, Array.Empty<PackageDependency>()),
+                new PackageDependencyGroup(CommonFrameworks.NetStandard16, Array.Empty<PackageDependency>()),
+                new PackageDependencyGroup(CommonFrameworks.NetStandard20, Array.Empty<PackageDependency>()),
+                new PackageDependencyGroup(CommonFrameworks.NetStandard21, Array.Empty<PackageDependency>())
+            };
+
+            IEnumerable<RegistryTargetFramework> targetFrameworks = new RegistryTargetFramework[] { new RegistryTargetFramework { Framework = CommonFrameworks.NetStandard20 } };
+
+            IEnumerable<PackageDependencyGroup> compatibleDependencyGroups = NuGetHelper.GetCompatiblePackageDependencyGroups(packageDependencyGroups, targetFrameworks);
+
+            CollectionAssert.AreEqual(new PackageDependencyGroup[] { packageDependencyGroups[2] }, compatibleDependencyGroups);
+        }
+
+        [Test]
+        public void GetCompatiblePackageDependencyGroups_SpecificMultipleFrameworks()
+        {
+            IList<PackageDependencyGroup> packageDependencyGroups = new PackageDependencyGroup[]
+            {
+                new PackageDependencyGroup(CommonFrameworks.NetStandard13, Array.Empty<PackageDependency>()),
+                new PackageDependencyGroup(CommonFrameworks.NetStandard16, Array.Empty<PackageDependency>()),
+                new PackageDependencyGroup(CommonFrameworks.NetStandard20, Array.Empty<PackageDependency>()),
+                new PackageDependencyGroup(CommonFrameworks.NetStandard21, Array.Empty<PackageDependency>())
+            };
+
+            IEnumerable<RegistryTargetFramework> targetFrameworks = new RegistryTargetFramework[] { new RegistryTargetFramework { Framework = CommonFrameworks.NetStandard20 }, new RegistryTargetFramework { Framework = CommonFrameworks.NetStandard21 } };
+
+            IEnumerable<PackageDependencyGroup> compatibleDependencyGroups = NuGetHelper.GetCompatiblePackageDependencyGroups(packageDependencyGroups, targetFrameworks);
+
+            CollectionAssert.AreEqual(new PackageDependencyGroup[] { packageDependencyGroups[2], packageDependencyGroups[3] }, compatibleDependencyGroups);
+        }
+
+        [Test]
+        public void GetCompatiblePackageDependencyGroups_AnyFramework()
+        {
+            IList<PackageDependencyGroup> packageDependencyGroups = new PackageDependencyGroup[]
+            {
+                new PackageDependencyGroup(new NuGetFramework(SpecialIdentifiers.Any), Array.Empty<PackageDependency>())
+            };
+
+            IEnumerable<RegistryTargetFramework> targetFrameworks = new RegistryTargetFramework[] { new RegistryTargetFramework { Framework = CommonFrameworks.NetStandard20 } };
+
+            IEnumerable<PackageDependencyGroup> compatibleDependencyGroups = NuGetHelper.GetCompatiblePackageDependencyGroups(packageDependencyGroups, targetFrameworks);
+
+            CollectionAssert.AreEqual(packageDependencyGroups, compatibleDependencyGroups);
+        }
+    }
+}

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -1,12 +1,22 @@
 ﻿using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.PackageManagement;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
 using NUnit.Framework;
+using static NuGet.Frameworks.FrameworkConstants;
 
 namespace UnityNuGet.Tests
 {
     public class RegistryTests
     {
         [Test]
-        public void TestSort()
+        public void Make_Sure_That_The_Order_In_The_Registry_Is_Respected()
         {
             var registry = Registry.GetInstance();
             var originalPackageNames = registry.Select(r => r.Key).ToArray();
@@ -16,12 +26,92 @@ namespace UnityNuGet.Tests
         }
 
         [Test]
-        public void TestBuiltInPackages()
+        public void Ensure_That_Packages_Already_Included_In_Net_Standard_Are_not_Included_In_The_Registry()
         {
             var registry = Registry.GetInstance();
             var packageNames = registry.Select(r => r.Key).Where(DotNetHelper.IsNetStandard20Assembly).ToArray();
 
             Assert.IsEmpty(packageNames);
+        }
+
+        [Test]
+        public async Task Ensure_Min_Version_Is_Correct_Ignoring_Analyzers_And_Native_Libs()
+        {
+            var registry = Registry.GetInstance();
+
+            var logger = NullLogger.Instance;
+            var cancellationToken = CancellationToken.None;
+
+            var cache = new SourceCacheContext();
+            var repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
+            var resource = await repository.GetResourceAsync<PackageMetadataResource>();
+
+            var nuGetFrameworks = new RegistryTargetFramework[] { new RegistryTargetFramework { Framework = CommonFrameworks.NetStandard20 } };
+
+            var excludedPackages = new string[] {
+                // All versions target "Any" and not .netstandard2.0 / 2.1
+                @"AWSSDK.S3",
+                // Although 2.x targets .netstandard2.0 it has an abandoned dependency (Remotion.Linq) that does not target .netstandard2.0.
+                // 3.1.0 is set because 3.0.x only targets .netstandard2.1.
+                @"Microsoft.EntityFrameworkCore.*",
+                // Versions < 1.4.1 has dependencies on Microsoft.AspNetCore.*.
+                @"StrongInject.Extensions.DependencyInjection",
+                // Versions < 4.6.0 in theory supports .netstandard2.0 but it doesn't have a lib folder with assemblies and it makes it fail.
+                @"System.Private.ServiceModel",
+                // Versions < 0.8.6 depend on LiteGuard, a deprecated dependency.
+                @"Telnet"
+            };
+
+            var excludedPackagesRegex = new Regex(@$"^{string.Join('|', excludedPackages)}$");
+
+            foreach (var registryKvp in registry.Where(r => !r.Value.Analyzer && !r.Value.Ignored))
+            {
+                var packageId = registryKvp.Key;
+
+                if (excludedPackagesRegex.IsMatch(packageId))
+                {
+                    continue;
+                }
+
+                var versionRange = registryKvp.Value.Version;
+
+                var dependencyPackageMetas = await resource.GetMetadataAsync(
+                    packageId,
+                    includePrerelease: false,
+                    includeUnlisted: false,
+                    cache,
+                    logger,
+                    cancellationToken);
+
+                var packageIdentity = NuGetHelper.GetMinimumCompatiblePackageIdentity(dependencyPackageMetas, nuGetFrameworks, includeAny: false);
+
+                if (packageIdentity != null)
+                {
+                    Assert.AreEqual(packageIdentity.Version, versionRange.MinVersion, $"Package {packageId}");
+                }
+                else
+                {
+                    var settings = Settings.LoadDefaultSettings(root: null);
+
+                    var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                            new SourceRepository[] { repository },
+                            new PackageIdentity(registryKvp.Key, registryKvp.Value.Version.MinVersion),
+                            new PackageDownloadContext(cache),
+                            SettingsUtility.GetGlobalPackagesFolder(settings),
+                            logger, cancellationToken);
+
+                    var hasNativeLib = await NativeLibraries.GetSupportedNativeLibsAsync(downloadResult.PackageReader, logger).AnyAsync();
+
+                    if (hasNativeLib)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        Assert.Fail(packageId);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -14,5 +14,14 @@ namespace UnityNuGet.Tests
 
             Assert.AreEqual(sortedPackageNames, originalPackageNames);
         }
+
+        [Test]
+        public void TestBuiltInPackages()
+        {
+            var registry = Registry.GetInstance();
+            var packageNames = registry.Select(r => r.Key).Where(DotNetHelper.IsNetStandard20Assembly).ToArray();
+
+            Assert.IsEmpty(packageNames);
+        }
     }
 }

--- a/src/UnityNuGet.Tests/UnityNuGet.Tests.csproj
+++ b/src/UnityNuGet.Tests/UnityNuGet.Tests.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="nunit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/UnityNuGet/DotNetHelper.cs
+++ b/src/UnityNuGet/DotNetHelper.cs
@@ -3,15 +3,131 @@
 namespace UnityNuGet
 {
     /// <summary>
-    /// Helper class to identify which NuGet packages are replaced by .NET Standard 2.1
+    /// Helper class to identify which NuGet packages are replaced by .NET Standard 2.0 / 2.1
     /// </summary>
     static class DotNetHelper
     {
-        public static bool IsNetStandard21Assembly(string packageId)
-        {
-            return NetStandard21Assemblies.Contains(packageId);
-        }
+        public static bool IsNetStandard20Assembly(string packageId) => NetStandard20Assemblies.Contains(packageId);
 
+        public static bool IsNetStandard21Assembly(string packageId) => NetStandard21Assemblies.Contains(packageId);
+
+        // Retrieved from NuGet package (/build/netstandard2.0/ref): https://www.nuget.org/packages/NETStandard.Library/2.0.3
+        private static readonly HashSet<string> NetStandard20Assemblies = new()
+        {
+            "Microsoft.Win32.Primitives",
+            "System.AppContext",
+            "System.Collections.Concurrent",
+            "System.Collections",
+            "System.Collections.NonGeneric",
+            "System.Collections.Specialized",
+            "System.ComponentModel.Composition",
+            "System.ComponentModel",
+            "System.ComponentModel.EventBasedAsync",
+            "System.ComponentModel.Primitives",
+            "System.ComponentModel.TypeConverter",
+            "System.Console",
+            "System.Core",
+            "System.Data.Common",
+            "System.Data",
+            "System.Diagnostics.Contracts",
+            "System.Diagnostics.Debug",
+            "System.Diagnostics.FileVersionInfo",
+            "System.Diagnostics.Process",
+            "System.Diagnostics.StackTrace",
+            "System.Diagnostics.TextWriterTraceListener",
+            "System.Diagnostics.Tools",
+            "System.Diagnostics.TraceSource",
+            "System.Diagnostics.Tracing",
+            "System",
+            "System.Drawing",
+            "System.Drawing.Primitives",
+            "System.Dynamic.Runtime",
+            "System.Globalization.Calendars",
+            "System.Globalization",
+            "System.Globalization.Extensions",
+            "System.IO.Compression",
+            "System.IO.Compression.FileSystem",
+            "System.IO.Compression.ZipFile",
+            "System.IO",
+            "System.IO.FileSystem",
+            "System.IO.FileSystem.DriveInfo",
+            "System.IO.FileSystem.Primitives",
+            "System.IO.FileSystem.Watcher",
+            "System.IO.IsolatedStorage",
+            "System.IO.MemoryMappedFiles",
+            "System.IO.Pipes",
+            "System.IO.UnmanagedMemoryStream",
+            "System.Linq",
+            "System.Linq.Expressions",
+            "System.Linq.Parallel",
+            "System.Linq.Queryable",
+            "System.Net",
+            "System.Net.Http",
+            "System.Net.NameResolution",
+            "System.Net.NetworkInformation",
+            "System.Net.Ping",
+            "System.Net.Primitives",
+            "System.Net.Requests",
+            "System.Net.Security",
+            "System.Net.Sockets",
+            "System.Net.WebHeaderCollection",
+            "System.Net.WebSockets.Client",
+            "System.Net.WebSockets",
+            "System.Numerics",
+            "System.ObjectModel",
+            "System.Reflection",
+            "System.Reflection.Extensions",
+            "System.Reflection.Primitives",
+            "System.Resources.Reader",
+            "System.Resources.ResourceManager",
+            "System.Resources.Writer",
+            "System.Runtime.CompilerServices.VisualC",
+            "System.Runtime",
+            "System.Runtime.Extensions",
+            "System.Runtime.Handles",
+            "System.Runtime.InteropServices",
+            "System.Runtime.InteropServices.RuntimeInformation",
+            "System.Runtime.Numerics",
+            "System.Runtime.Serialization",
+            "System.Runtime.Serialization.Formatters",
+            "System.Runtime.Serialization.Json",
+            "System.Runtime.Serialization.Primitives",
+            "System.Runtime.Serialization.Xml",
+            "System.Security.Claims",
+            "System.Security.Cryptography.Algorithms",
+            "System.Security.Cryptography.Csp",
+            "System.Security.Cryptography.Encoding",
+            "System.Security.Cryptography.Primitives",
+            "System.Security.Cryptography.X509Certificates",
+            "System.Security.Principal",
+            "System.Security.SecureString",
+            "System.ServiceModel.Web",
+            "System.Text.Encoding",
+            "System.Text.Encoding.Extensions",
+            "System.Text.RegularExpressions",
+            "System.Threading",
+            "System.Threading.Overlapped",
+            "System.Threading.Tasks",
+            "System.Threading.Tasks.Parallel",
+            "System.Threading.Thread",
+            "System.Threading.ThreadPool",
+            "System.Threading.Timer",
+            "System.Transactions",
+            "System.ValueTuple",
+            "System.Web",
+            "System.Windows",
+            "System.Xml",
+            "System.Xml.Linq",
+            "System.Xml.ReaderWriter",
+            "System.Xml.Serialization",
+            "System.Xml.XDocument",
+            "System.Xml.XmlDocument",
+            "System.Xml.XmlSerializer",
+            "System.Xml.XPath",
+            "System.Xml.XPath.XDocument"
+        };
+
+        // Retrieved from NuGet package (/ref/netstandard2.1): https://www.nuget.org/packages/NETStandard.Library.Ref
         private static readonly HashSet<string> NetStandard21Assemblies = new()
         {
             "Microsoft.Win32.Primitives",
@@ -118,7 +234,5 @@ namespace UnityNuGet
             "System.Xml.XPath",
             "System.Xml.XPath.XDocument",
         };
-
-
     }
 }

--- a/src/UnityNuGet/NuGetHelper.cs
+++ b/src/UnityNuGet/NuGetHelper.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+
+namespace UnityNuGet
+{
+    static class NuGetHelper
+    {
+        public static IEnumerable<(FrameworkSpecificGroup, RegistryTargetFramework)> GetClosestFrameworkSpecificGroups(IEnumerable<FrameworkSpecificGroup> versions, IEnumerable<RegistryTargetFramework> targetFrameworks)
+        {
+            var result = new List<(FrameworkSpecificGroup, RegistryTargetFramework)>();
+
+            foreach (var targetFramework in targetFrameworks)
+            {
+                var item = versions.Where(x => x.TargetFramework.Framework == targetFramework.Framework!.Framework && x.TargetFramework.Version <= targetFramework.Framework.Version).OrderByDescending(x => x.TargetFramework.Version)
+                    .FirstOrDefault();
+
+                if (item != null)
+                {
+                    result.Add((item, targetFramework));
+                }
+            }
+
+            return result;
+        }
+
+        public static IEnumerable<PackageDependencyGroup> GetCompatiblePackageDependencyGroups(IEnumerable<PackageDependencyGroup> packageDependencyGroups, IEnumerable<RegistryTargetFramework> targetFrameworks, bool includeAny = true)
+        {
+            return packageDependencyGroups.Where(dependencySet => (includeAny && dependencySet.TargetFramework.IsAny) || targetFrameworks.Any(targetFramework => dependencySet.TargetFramework == targetFramework.Framework)).ToList();
+        }
+
+        public static PackageIdentity? GetMinimumCompatiblePackageIdentity(IEnumerable<IPackageSearchMetadata> packageSearchMetadataIt, IEnumerable<RegistryTargetFramework> targetFrameworks, bool includeAny = true)
+        {
+            foreach (var packageSearchMetadata in packageSearchMetadataIt)
+            {
+                var dependencyResolvedDependencyGroups = GetCompatiblePackageDependencyGroups(packageSearchMetadata.DependencySets, targetFrameworks, includeAny);
+
+                if (dependencyResolvedDependencyGroups.Any())
+                {
+                    return packageSearchMetadata.Identity;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/UnityNuGet/Registry.cs
+++ b/src/UnityNuGet/Registry.cs
@@ -16,7 +16,9 @@ namespace UnityNuGet
         private static readonly object LockRead = new();
         private static Registry? _registry = null;
 
-        public Registry()
+        // A comparer is established for cases where the dependency name is not set to the correct case.
+        // Example: https://www.nuget.org/packages/NeoSmart.Caching.Sqlite/0.1.0#dependencies-body-tab
+        public Registry() : base(StringComparer.OrdinalIgnoreCase)
         {
         }
 

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -229,7 +229,7 @@ namespace UnityNuGet
                         continue;
                     }
 
-                    var resolvedDependencyGroups = packageMeta.DependencySets.Where(dependencySet => dependencySet.TargetFramework.IsAny || _targetFrameworks.Any(targetFramework => dependencySet.TargetFramework == targetFramework.Framework)).ToList();
+                    var resolvedDependencyGroups = NuGetHelper.GetCompatiblePackageDependencyGroups(packageMeta.DependencySets, _targetFrameworks);
 
                     var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
                         _sourceRepositories,
@@ -240,7 +240,7 @@ namespace UnityNuGet
 
                     var hasNativeLib = await NativeLibraries.GetSupportedNativeLibsAsync(downloadResult.PackageReader, _logger).AnyAsync();
 
-                    if (!packageEntry.Analyzer && resolvedDependencyGroups.Count == 0 && !hasNativeLib)
+                    if (!packageEntry.Analyzer && !resolvedDependencyGroups.Any() && !hasNativeLib)
                     {
                         LogWarning($"The package `{packageIdentity}` doesn't support `{string.Join(",", _targetFrameworks.Select(x => x.Name))}`");
                         continue;
@@ -320,10 +320,16 @@ namespace UnityNuGet
                     {
                         foreach (var deps in resolvedDependencyGroup.Packages)
                         {
+                            if (DotNetHelper.IsNetStandard20Assembly(deps.Id))
+                            {
+                                continue;
+                            }
+
+                            PackageDependency resolvedDeps = deps;
 
                             if (!_registry.TryGetValue(deps.Id, out var packageEntryDep))
                             {
-                                LogWarning($"The package `{packageIdentity}` has a dependency on `{deps.Id}` which is not in the registry. You must add this dependency to the registry.json file.");
+                                LogError($"The package `{packageIdentity}` has a dependency on `{deps.Id}` which is not in the registry. You must add this dependency to the registry.json file.");
                                 hasDependencyErrors = true;
                             }
                             else if (packageEntryDep.Ignored)
@@ -333,17 +339,48 @@ namespace UnityNuGet
                             }
                             else if (!deps.VersionRange.IsSubSetOrEqualTo(packageEntryDep.Version))
                             {
-                                LogWarning($"The version range `{deps.VersionRange}` for the dependency `{deps.Id}` for the package `{packageIdentity}` doesn't match the range allowed from the registry.json: `{packageEntryDep.Version}`");
-                                hasDependencyErrors = true;
-                                continue;
+                                var dependencyPackageMetaIt = await GetMetadataFromSources(deps.Id);
+                                var dependencyPackageMetas = dependencyPackageMetaIt != null ? dependencyPackageMetaIt.ToArray() : Array.Empty<IPackageSearchMetadata>();
+
+                                PackageDependency? packageDependency = null;
+
+                                foreach (var dependencyPackageMeta in dependencyPackageMetas)
+                                {
+                                    var dependencyResolvedDependencyGroups = NuGetHelper.GetCompatiblePackageDependencyGroups(dependencyPackageMeta.DependencySets, _targetFrameworks, includeAny: false);
+
+                                    if (dependencyResolvedDependencyGroups.Any())
+                                    {
+                                        _registry.TryGetValue(dependencyPackageMeta.Identity.Id, out var registryEntry);
+
+                                        var registryMinimumVersion = registryEntry?.Version?.MinVersion;
+
+                                        NuGetVersion newVersion = registryMinimumVersion > dependencyPackageMeta.Identity.Version ? registryMinimumVersion : dependencyPackageMeta.Identity.Version;
+
+                                        packageDependency = new PackageDependency(dependencyPackageMeta.Identity.Id, new VersionRange(newVersion));
+
+                                        break;
+                                    }
+                                }
+
+                                if (packageDependency != null)
+                                {
+                                    resolvedDeps = packageDependency;
+                                    LogWarning($"Overwriting dependency `{deps.Id} {deps.VersionRange}` of the package `{packageIdentity}` in favor of `{resolvedDeps.Id} {resolvedDeps.VersionRange}` because it is not compatible with {string.Join(",", _targetFrameworks.Select(x => x.Name))}.");
+                                }
+                                else
+                                {
+                                    LogWarning($"The version range `{deps.VersionRange}` for the dependency `{deps.Id}` for the package `{packageIdentity}` doesn't match the range allowed from the registry.json: `{packageEntryDep.Version}`");
+                                    hasDependencyErrors = true;
+                                    continue;
+                                }
                             }
 
                             // Otherwise add the package as a dependency
-                            var depsId = deps.Id.ToLowerInvariant();
+                            var depsId = resolvedDeps.Id.ToLowerInvariant();
                             var key = $"{_unityScope}.{depsId}";
                             if (!npmVersion.Dependencies.ContainsKey(key))
                             {
-                                npmVersion.Dependencies.Add(key, GetNpmVersion(deps.VersionRange.MinVersion));
+                                npmVersion.Dependencies.Add(key, GetNpmVersion(resolvedDeps.VersionRange.MinVersion));
                             }
                         }
                     }
@@ -406,7 +443,7 @@ namespace UnityNuGet
             }
             else
             {
-                npmPackageVersion.Distribution.Shasum = ReadUnityPackageSha1(identity, npmPackageVersion);
+                npmPackageVersion.Distribution.Shasum = await ReadUnityPackageSha1(identity, npmPackageVersion);
             }
         }
 
@@ -455,21 +492,20 @@ namespace UnityNuGet
                 using (var tarArchive = new TarOutputStream(gzoStream, Encoding.UTF8))
                 {
                     // Select the framework version that is the closest or equal to the latest configured framework version
-                    var versions = (await packageReader.GetLibItemsAsync(CancellationToken.None)).ToList();
+                    var versions = await packageReader.GetLibItemsAsync(CancellationToken.None);
+
+                    var closestVersions = NuGetHelper.GetClosestFrameworkSpecificGroups(versions, _targetFrameworks);
 
                     var collectedItems = new Dictionary<FrameworkSpecificGroup, HashSet<RegistryTargetFramework>>();
 
-                    foreach (var targetFramework in _targetFrameworks)
+                    foreach (var closestVersion in closestVersions)
                     {
-                        var item = versions.Where(x => x.TargetFramework.Framework == targetFramework.Framework?.Framework && x.TargetFramework.Version <= targetFramework.Framework.Version).OrderByDescending(x => x.TargetFramework.Version)
-                            .FirstOrDefault();
-                        if (item == null) continue;
-                        if (!collectedItems.TryGetValue(item, out var frameworksPerGroup))
+                        if (!collectedItems.TryGetValue(closestVersion.Item1, out var frameworksPerGroup))
                         {
                             frameworksPerGroup = new HashSet<RegistryTargetFramework>();
-                            collectedItems.Add(item, frameworksPerGroup);
+                            collectedItems.Add(closestVersion.Item1, frameworksPerGroup);
                         }
-                        frameworksPerGroup.Add(targetFramework);
+                        frameworksPerGroup.Add(closestVersion.Item2);
                     }
 
                     if (!packageEntry.Analyzer && collectedItems.Count == 0)
@@ -488,13 +524,13 @@ namespace UnityNuGet
 
                     if (packageEntry.Analyzer)
                     {
-                        var packageFiles = (await packageReader.GetPackageFilesAsync(PackageSaveMode.Files, CancellationToken.None)).ToList();
+                        var packageFiles = await packageReader.GetItemsAsync(PackagingConstants.Folders.Analyzers, CancellationToken.None);
 
-                        var analyzerFiles = packageFiles.Where(p => p.StartsWith("analyzers/dotnet/cs")).ToArray();
+                        var analyzerFiles = packageFiles.SelectMany(p => p.Items).Where(p => p.StartsWith("analyzers/dotnet/cs")).ToArray();
 
                         if (analyzerFiles.Length == 0)
                         {
-                            analyzerFiles = packageFiles.Where(p => p.StartsWith("analyzers")).ToArray();
+                            analyzerFiles = packageFiles.SelectMany(p => p.Items).Where(p => p.StartsWith("analyzers")).ToArray();
                         }
 
                         var createdDirectoryList = new List<string>();
@@ -523,7 +559,7 @@ namespace UnityNuGet
                                     createdDirectoryList.Add(processedDirectoryName);
 
                                     // write meta file for the folder
-                                    WriteTextFileToTar(tarArchive, $"{processedDirectoryName}.meta", UnityMeta.GetMetaForFolder(GetStableGuid(identity, processedDirectoryName)));
+                                    await WriteTextFileToTar(tarArchive, $"{processedDirectoryName}.meta", UnityMeta.GetMetaForFolder(GetStableGuid(identity, processedDirectoryName)));
                                 }
                             }
 
@@ -548,15 +584,15 @@ namespace UnityNuGet
                             memStream.Position = 0;
                             memStream.SetLength(0);
 
-                            var stream = packageReader.GetStream(analyzerFile);
+                            var stream = await packageReader.GetStreamAsync(analyzerFile, CancellationToken.None);
                             await stream.CopyToAsync(memStream);
                             var buffer = memStream.ToArray();
 
                             // write content
-                            WriteBufferToTar(tarArchive, fileInUnityPackage, buffer);
+                            await WriteBufferToTar(tarArchive, fileInUnityPackage, buffer);
 
                             // write meta file
-                            WriteTextFileToTar(tarArchive, $"{fileInUnityPackage}.meta", meta);
+                            await WriteTextFileToTar(tarArchive, $"{fileInUnityPackage}.meta", meta);
                         }
                     }
 
@@ -595,22 +631,22 @@ namespace UnityNuGet
                             memStream.Position = 0;
                             memStream.SetLength(0);
 
-                            var stream = packageReader.GetStream(file);
+                            var stream = await packageReader.GetStreamAsync(file, CancellationToken.None);
                             await stream.CopyToAsync(memStream);
                             var buffer = memStream.ToArray();
 
                             // write content
-                            WriteBufferToTar(tarArchive, fileInUnityPackage, buffer);
+                            await WriteBufferToTar(tarArchive, fileInUnityPackage, buffer);
 
                             // write meta file
-                            WriteTextFileToTar(tarArchive, $"{fileInUnityPackage}.meta", meta);
+                            await WriteTextFileToTar(tarArchive, $"{fileInUnityPackage}.meta", meta);
                         }
 
                         // Write folder meta
                         if (!string.IsNullOrEmpty(folderPrefix) && item.Items.Any())
                         {
                             // write meta file for the folder
-                            WriteTextFileToTar(tarArchive, $"{folderPrefix[0..^1]}.meta", UnityMeta.GetMetaForFolder(GetStableGuid(identity, folderPrefix)));
+                            await WriteTextFileToTar(tarArchive, $"{folderPrefix[0..^1]}.meta", UnityMeta.GetMetaForFolder(GetStableGuid(identity, folderPrefix)));
                         }
                     }
 
@@ -644,8 +680,8 @@ namespace UnityNuGet
                         await stream.CopyToAsync(memStream);
                         var buffer = memStream.ToArray();
 
-                        WriteBufferToTar(tarArchive, file, buffer);
-                        WriteTextFileToTar(tarArchive, $"{file}.meta", meta);
+                        await WriteBufferToTar(tarArchive, file, buffer);
+                        await WriteTextFileToTar(tarArchive, $"{file}.meta", meta);
 
                         // Remember all folders for meta files
                         string folder = "";
@@ -659,15 +695,15 @@ namespace UnityNuGet
 
                     foreach (var folder in nativeFolders)
                     {
-                        WriteTextFileToTar(tarArchive, $"{folder}.meta", UnityMeta.GetMetaForFolder(GetStableGuid(identity, folder)));
+                        await WriteTextFileToTar(tarArchive, $"{folder}.meta", UnityMeta.GetMetaForFolder(GetStableGuid(identity, folder)));
                     }
 
                     // Write the package,json
                     var unityPackage = CreateUnityPackage(npmPackageInfo, npmPackageVersion);
                     var unityPackageAsJson = unityPackage.ToJson();
                     const string packageJsonFileName = "package.json";
-                    WriteTextFileToTar(tarArchive, packageJsonFileName, unityPackageAsJson);
-                    WriteTextFileToTar(tarArchive, $"{packageJsonFileName}.meta", UnityMeta.GetMetaForExtension(GetStableGuid(identity, packageJsonFileName), ".json")!);
+                    await WriteTextFileToTar(tarArchive, packageJsonFileName, unityPackageAsJson);
+                    await WriteTextFileToTar(tarArchive, $"{packageJsonFileName}.meta", UnityMeta.GetMetaForExtension(GetStableGuid(identity, packageJsonFileName), ".json")!);
 
                     // Write the license to the package if any
                     string? license = null;
@@ -721,15 +757,15 @@ namespace UnityNuGet
                     if (!string.IsNullOrEmpty(license))
                     {
                         const string licenseMdFile = "License.md";
-                        WriteTextFileToTar(tarArchive, licenseMdFile, license);
-                        WriteTextFileToTar(tarArchive, $"{licenseMdFile}.meta", UnityMeta.GetMetaForExtension(GetStableGuid(identity, licenseMdFile), ".md")!);
+                        await WriteTextFileToTar(tarArchive, licenseMdFile, license);
+                        await WriteTextFileToTar(tarArchive, $"{licenseMdFile}.meta", UnityMeta.GetMetaForExtension(GetStableGuid(identity, licenseMdFile), ".md")!);
                     }
                 }
 
                 using (var stream = File.OpenRead(unityPackageFilePath))
                 {
                     var sha1 = Sha1sum(stream);
-                    WriteUnityPackageSha1(identity, npmPackageVersion, sha1);
+                    await WriteUnityPackageSha1(identity, npmPackageVersion, sha1);
                     npmPackageVersion.Distribution.Shasum = sha1;
                 }
             }
@@ -794,31 +830,31 @@ namespace UnityNuGet
             return sha1File.Exists && sha1File.Length > 0;
         }
 
-        private string ReadUnityPackageSha1(PackageIdentity identity, NpmPackageVersion packageVersion)
+        private async Task<string> ReadUnityPackageSha1(PackageIdentity identity, NpmPackageVersion packageVersion)
         {
-            return File.ReadAllText(GetUnityPackageSha1Path(identity, packageVersion));
+            return await File.ReadAllTextAsync(GetUnityPackageSha1Path(identity, packageVersion));
         }
 
-        private void WriteUnityPackageSha1(PackageIdentity identity, NpmPackageVersion packageVersion, string sha1)
+        private async Task WriteUnityPackageSha1(PackageIdentity identity, NpmPackageVersion packageVersion, string sha1)
         {
-            File.WriteAllText(GetUnityPackageSha1Path(identity, packageVersion), sha1);
+            await File.WriteAllTextAsync(GetUnityPackageSha1Path(identity, packageVersion), sha1);
         }
 
         private string GetUnityPackagePath(PackageIdentity identity, NpmPackageVersion packageVersion) => Path.Combine(_rootPersistentFolder, GetUnityPackageFileName(identity, packageVersion));
 
         private string GetUnityPackageSha1Path(PackageIdentity identity, NpmPackageVersion packageVersion) => Path.Combine(_rootPersistentFolder, GetUnityPackageSha1FileName(identity, packageVersion));
 
-        private static void WriteTextFileToTar(TarOutputStream tarOut, string filePath, string content)
+        private static async Task WriteTextFileToTar(TarOutputStream tarOut, string filePath, string content, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(tarOut);
             ArgumentNullException.ThrowIfNull(filePath);
             ArgumentNullException.ThrowIfNull(content);
 
             var buffer = Utf8EncodingNoBom.GetBytes(content);
-            WriteBufferToTar(tarOut, filePath, buffer);
+            await WriteBufferToTar(tarOut, filePath, buffer, cancellationToken);
         }
 
-        private static void WriteBufferToTar(TarOutputStream tarOut, string filePath, byte[] buffer)
+        private static async Task WriteBufferToTar(TarOutputStream tarOut, string filePath, byte[] buffer, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(tarOut);
             ArgumentNullException.ThrowIfNull(filePath);
@@ -829,9 +865,9 @@ namespace UnityNuGet
 
             var tarEntry = TarEntry.CreateTarEntry($"package/{filePath}");
             tarEntry.Size = buffer.Length;
-            tarOut.PutNextEntry(tarEntry);
-            tarOut.Write(buffer, 0, buffer.Length);
-            tarOut.CloseEntry();
+            await tarOut.PutNextEntryAsync(tarEntry, cancellationToken);
+            await tarOut.WriteAsync(buffer, cancellationToken);
+            await tarOut.CloseEntryAsync(cancellationToken);
         }
 
         private static UnityPackage CreateUnityPackage(NpmPackageInfo npmPackageInfo, NpmPackageVersion npmPackageVersion)

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -364,8 +364,17 @@ namespace UnityNuGet
 
                                 if (packageDependency != null)
                                 {
-                                    resolvedDeps = packageDependency;
-                                    LogWarning($"Overwriting dependency `{deps.Id} {deps.VersionRange}` of the package `{packageIdentity}` in favor of `{resolvedDeps.Id} {resolvedDeps.VersionRange}` because it is not compatible with {string.Join(",", _targetFrameworks.Select(x => x.Name))}.");
+                                    if (deps.VersionRange.MinVersion > packageDependency.VersionRange.MinVersion)
+                                    {
+                                        packageDependency = new PackageDependency(packageDependency.Id, deps.VersionRange);
+                                        resolvedDeps = packageDependency;
+                                        continue;
+                                    }
+                                    else
+                                    {
+                                        resolvedDeps = packageDependency;
+                                        LogWarning($"Overwriting dependency `{deps.Id} {deps.VersionRange}` of the package `{packageIdentity}` in favor of `{resolvedDeps.Id} {resolvedDeps.VersionRange}` because it is not compatible with {string.Join(",", _targetFrameworks.Select(x => x.Name))}.");
+                                    }
                                 }
                                 else
                                 {

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -852,11 +852,8 @@ namespace UnityNuGet
         {
             var guid = new byte[16];
             var inputBytes = Encoding.UTF8.GetBytes(text);
-            using (var algorithm = SHA1.Create())
-            {
-                var hash = algorithm.ComputeHash(inputBytes);
-                Array.Copy(hash, 0, guid, 0, guid.Length);
-            }
+            var hash = SHA1.HashData(inputBytes);
+            Array.Copy(hash, 0, guid, 0, guid.Length);
 
             // Follow UUID for SHA1 based GUID 
             const int version = 5; // SHA1 (3 for MD5)
@@ -867,8 +864,7 @@ namespace UnityNuGet
 
         private static string Sha1sum(Stream stream)
         {
-            using var sha1 = SHA1.Create();
-            var hash = sha1.ComputeHash(stream);
+            var hash = SHA1.HashData(stream);
             var sb = new StringBuilder(hash.Length * 2);
 
             foreach (byte b in hash)

--- a/src/UnityNuGet/UnityNuGet.csproj
+++ b/src/UnityNuGet/UnityNuGet.csproj
@@ -25,8 +25,8 @@
       <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
       <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" /> 
-      <PackageReference Include="NUglify" Version="1.20.2" /> 
-      <PackageReference Include="Scriban" Version="5.5.0" /> 
+      <PackageReference Include="NUglify" Version="1.20.4" /> 
+      <PackageReference Include="Scriban" Version="5.5.1" /> 
       <PackageReference Include="SharpZipLib" Version="1.4.1" /> 
       <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" /> 
       <PackageReference Include="System.Linq.Async" Version="6.0.1" /> 


### PR DESCRIPTION
Fixes #160 #163

Unlocks #120 #158 

**Readme.md:**

- Explain how to add the registry scope both by hand (manifest.json) and through the package manager UI.
- Explain how to disable assembly version validation
- Explain where is the Unity cache by OS
- Help link on how to create a PAT
- Small formatting modifications

**registry.json:**

- Set minimum version compatible with .NET Standard 2.0 per package

**Code:**

- Update DotNetHelper class to add .NET Standard 2.0 included assemblies
- Fix Scriban's LoopLimit error
- Update NuGet packages
- Change synchronous APIs to asynchronous APIs
- Improve analyzers NuGet API usage and switch GetPackageFilesAsync to GetItemsAsync and retrieve Analyzers folder directly
- Overwrite dependencies when containing a dependency that is not compatible with .NET Standard 2.0
- Do not overwrite the version if the minimum version is already higher than the minimum version compatible with .NET Standard 2.0

**Tests:**

- Add test to check that dependencies already included in .NET Standard 2.0 are not added to registry.json file
