### PR TITLE
Register Serilog.Formatting.Compact

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -803,6 +803,10 @@
     "listed": true,
     "version": "2.0.0"
   },
+  "Serilog.Formatting.Compact": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "Serilog.Settings.Configuration": {
     "listed": true,
     "version": "3.0.0"

--- a/registry.json
+++ b/registry.json
@@ -805,7 +805,7 @@
   },
   "Serilog.Formatting.Compact": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "Serilog.Settings.Configuration": {
     "listed": true,


### PR DESCRIPTION
Version 1.0.0 technically only supports .NET Standard 1.1, but I was able to use it in a Unity 2021.3.10f1 project targeting .NET Standard 2.1 just fine. I couldn't use the later version that _does_ support .NET Standard 2.0 ([1.1.0](https://www.nuget.org/packages/Serilog.Formatting.Compact/1.1.0#supportedframeworks-body-tab)) because it also depends on Serilog >=2.8.0, which UnityNuGet does not yet contain.

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Serilog.Formatting.Compact
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [ ] It must provide .NETStandard2.0 assemblies as part of its package
>     - See notes above
> - [ ] The lowest version added must be the lowest .NETStandard2.0 version available
>     - See notes above
> - [x] The package has been tested with the Unity editor (2021.3.10f1)
> - [x] The package has been tested with a Unity standalone player (Android)
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>     - Only Serilog, which is already registered
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


