### PR TITLE
Add AWSSDK.SecurityToken

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -35,6 +35,10 @@
     "listed": true,
     "version": "3.3.100"
   },
+  "AWSSDK.SecurityToken": {
+    "listed": true,
+    "version": "3.3.100"
+  },
   "Ben.Demystifier": {
     "listed": true,
     "version": "0.0.43"

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -51,6 +51,8 @@ namespace UnityNuGet.Tests
             var excludedPackages = new string[] {
                 // All versions target "Any" and not .netstandard2.0 / 2.1
                 @"AWSSDK.S3",
+                // All versions target "Any" and not .netstandard2.0 / 2.1
+                @"AWSSDK.SecurityToken",
                 // Although 2.x targets .netstandard2.0 it has an abandoned dependency (Remotion.Linq) that does not target .netstandard2.0.
                 // 3.1.0 is set because 3.0.x only targets .netstandard2.1.
                 @"Microsoft.EntityFrameworkCore.*",


### PR DESCRIPTION
As of MongoDB.Driver.Core version 2.19.0 is causing it to fail due to not having the AWS dependency registered.

![image](https://user-images.githubusercontent.com/950602/216908680-d535d596-b3ca-47b4-a4ee-181989f2f745.png)
