### PR TITLE
Avoid fetching NuGet packages if the cache is up-to-date

### DIFF
--- a/src/UnityNuGet/Npm/NpmPackageCacheEntry.cs
+++ b/src/UnityNuGet/Npm/NpmPackageCacheEntry.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Alexandre Mutel. All rights reserved.
+// Licensed under the BSD-Clause 2 license.
+// See license.txt file in the project root for full license information.
+
+using Newtonsoft.Json;
+
+namespace UnityNuGet.Npm
+{
+    public class NpmPackageCacheEntry : NpmObject
+    {
+        [JsonProperty("package")]
+        public NpmPackage? Package { get; set; }
+
+        [JsonProperty("info")]
+        public NpmPackageInfo? Info { get; set; }
+
+        [JsonIgnore]
+        public string? Json { get; set; }
+    }
+}

--- a/src/UnityNuGet/Npm/NpmPackageListAllResponse.cs
+++ b/src/UnityNuGet/Npm/NpmPackageListAllResponse.cs
@@ -41,5 +41,10 @@ namespace UnityNuGet.Npm
                 return marshalPackages;
             }
         }
+
+        public void Reset()
+        {
+            Packages.Clear();
+        }
     }
 }

--- a/src/UnityNuGet/Npm/NpmPackageRegistry.cs
+++ b/src/UnityNuGet/Npm/NpmPackageRegistry.cs
@@ -19,5 +19,20 @@ namespace UnityNuGet.Npm
         public NpmPackageListAllResponse ListedPackageInfos { get; }
 
         public NpmPackageListAllResponse UnlistedPackageInfos { get; }
+
+        public void AddPackage(NpmPackageCacheEntry entry, bool isListed)
+        {
+            var package = entry.Package!;
+            Packages.Add(package.Id!, package);
+            var packageInfos = isListed ? ListedPackageInfos : UnlistedPackageInfos;
+            packageInfos.Packages.Add(package.Id!, entry.Info!);
+        }
+
+        public void Reset()
+        {
+            Packages.Clear();
+            ListedPackageInfos.Reset();
+            UnlistedPackageInfos.Reset();
+        }
     }
 }

--- a/src/UnityNuGet/UnityNuGet.csproj
+++ b/src/UnityNuGet/UnityNuGet.csproj
@@ -22,12 +22,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
       <PackageReference Include="NuGet.PackageManagement" Version="6.4.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" /> 
-      <PackageReference Include="NUglify" Version="1.20.4" /> 
-      <PackageReference Include="Scriban" Version="5.5.2" /> 
-      <PackageReference Include="SharpZipLib" Version="1.4.1" /> 
+      <PackageReference Include="NUglify" Version="1.20.5" /> 
+      <PackageReference Include="Scriban" Version="5.6.0" /> 
+      <PackageReference Include="SharpZipLib" Version="1.4.2" /> 
       <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" /> 
       <PackageReference Include="System.Linq.Async" Version="6.0.1" /> 
     </ItemGroup>


### PR DESCRIPTION
cc: @bdovaz 

I have implemented the early cache skip as suggested in [comment](https://github.com/xoofx/UnityNuGet/issues/175#issuecomment-1435967067)

It seems to work locally (but tested only on a limited set of packages). Gonna try this on this CI before merging.


