### PR TITLE
Missing dependency should not be a blocker

### DIFF
--- a/src/UnityNuGet/Registry.cs
+++ b/src/UnityNuGet/Registry.cs
@@ -22,6 +22,10 @@ namespace UnityNuGet
         {
         }
 
+        public Registry(IEnumerable<KeyValuePair<string, RegistryEntry>> collection) : base(collection)
+        {
+        }
+
         private Registry(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }


### PR DESCRIPTION
At the moment any missing dependency becomes a show-stopper. This makes populating registry.json a tedious task. What if the RegistryCache would walk the dependency tree by default?

