### PR TITLE
Add Kdl.NetStandard.x64 (Fix Robots new missing dependency error)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -352,6 +352,10 @@
     "listed": true,
     "version": "1.0.2"
   },
+  "Kdl.NetStandard.x64": {
+    "listed": true,
+    "version": "2.0.0"
+  },
   "LiteDB": {
     "listed": true,
     "version": "4.0.0"


### PR DESCRIPTION
Fixes a problem generated by this new dependency of `Robots`.

![image](https://user-images.githubusercontent.com/950602/231103136-094121d4-d4cb-4828-9913-bb3e695c2630.png)

cc: @xoofx