### PR TITLE
Added Semver

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -352,6 +352,10 @@
     "listed": true,
     "version": "1.0.2"
   },
+  "Kdl.NetStandard.x64": {
+    "listed": true,
+    "version": "2.0.0"
+  },
   "LiteDB": {
     "listed": true,
     "version": "4.0.0"

--- a/registry.json
+++ b/registry.json
@@ -807,6 +807,10 @@
     "listed": true,
     "version": "3.0.1"
   },
+  "Semver": {
+    "listed": true,
+    "version": "2.1.0"
+  },
   "Serialization.NET": {
     "listed": true,
     "version": "1.0.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package: https://www.nuget.org/packages/Semver
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)