### PR TITLE
HarmonyX

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -347,6 +347,10 @@
       "UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN"
     ]
   },
+  "HarmonyX": {
+    "listed": true,
+    "version": "2.0.2"
+  },
   "IDisposableAnalyzers": {
     "listed": true,
     "version": "1.0.0",
@@ -725,6 +729,18 @@
   "MongoDB.Libmongocrypt": {
     "listed": true,
     "version": "1.2.0"
+  },
+  "Mono.Cecil": {
+    "listed": true,
+    "version": "0.11.0"
+  },
+  "MonoMod.RuntimeDetour": {
+    "listed": true,
+    "version": "18.11.9.9"
+  },
+  "MonoMod.Utils": {
+    "listed": true,
+    "version": "18.11.9.9"
   },
   "Moq": {
     "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -56,6 +56,9 @@ namespace UnityNuGet.Tests
                 // Although 2.x targets .netstandard2.0 it has an abandoned dependency (Remotion.Linq) that does not target .netstandard2.0.
                 // 3.1.0 is set because 3.0.x only targets .netstandard2.1.
                 @"Microsoft.EntityFrameworkCore.*",
+                // Monomod Versions < 18.11.9.9 depend on System.Runtime.Loader which doesn't ship .netstandard2.0.
+                @"MonoMod.Utils",
+                @"MonoMod.RuntimeDetour",
                 // Versions < 1.4.1 has dependencies on Microsoft.AspNetCore.*.
                 @"StrongInject.Extensions.DependencyInjection",
                 // Versions < 4.6.0 in theory supports .netstandard2.0 but it doesn't have a lib folder with assemblies and it makes it fail.


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/HarmonyX
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


