### PR TITLE
Add UNITY_EDITOR constraint to HarmonyX and related packages

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -349,7 +349,10 @@
   },
   "HarmonyX": {
     "listed": true,
-    "version": "2.0.2"
+    "version": "2.0.2",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
   },
   "IDisposableAnalyzers": {
     "listed": true,
@@ -732,15 +735,24 @@
   },
   "Mono.Cecil": {
     "listed": true,
-    "version": "0.11.0"
+    "version": "0.11.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
   },
   "MonoMod.RuntimeDetour": {
     "listed": true,
-    "version": "18.11.9.9"
+    "version": "18.11.9.9",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
   },
   "MonoMod.Utils": {
     "listed": true,
-    "version": "18.11.9.9"
+    "version": "18.11.9.9",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
   },
   "Moq": {
     "listed": true,


### PR DESCRIPTION
The packages added in #194 are used for runtime method patching, which only makes sense in an UNITY_EDITOR context.

(I spoke with @simonkellly before making this PR, his didn't know about `defineConstraints` and neither did I until I checked the issue log)