### PR TITLE
Add Microsoft.CodeAnalysis.CSharp and Microsoft.CodeAnalysis.Common

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -480,11 +480,17 @@
   },
   "Microsoft.CodeAnalysis.Common": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "3.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
   },
   "Microsoft.CodeAnalysis.CSharp": {
     "listed": true,
-    "version": "3.0.0"
+    "version": "3.0.0",
+    "defineConstraints": [
+      "UNITY_EDITOR"
+    ]
   },
   "Microsoft.CodeAnalysis.NetAnalyzers": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -468,6 +468,11 @@
     "listed": true,
     "version": "1.0.0"
   },
+  "Microsoft.CodeAnalysis.Analyzers": {
+    "listed": true,
+    "version": "3.0.0",
+    "analyzer": true
+  },
   "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
     "listed": true,
     "version": "2.9.0",

--- a/registry.json
+++ b/registry.json
@@ -18,7 +18,7 @@
   "AsyncKeyedLock": {
     "listed": true,
     "version": "1.0.0"
-  },  
+  },
   "AutoMapper": {
     "listed": true,
     "version": "7.0.1"
@@ -472,6 +472,14 @@
     "listed": true,
     "version": "2.9.0",
     "analyzer": true
+  },
+  "Microsoft.CodeAnalysis.Common": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "Microsoft.CodeAnalysis.CSharp": {
+    "listed": true,
+    "version": "3.0.0"
   },
   "Microsoft.CodeAnalysis.NetAnalyzers": {
     "listed": true,

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -564,14 +564,14 @@ namespace UnityNuGet
 
                     var collectedItems = new Dictionary<FrameworkSpecificGroup, HashSet<RegistryTargetFramework>>();
 
-                    foreach (var closestVersion in closestVersions)
+                    foreach (var (item, targetFramework) in closestVersions)
                     {
-                        if (!collectedItems.TryGetValue(closestVersion.Item1, out var frameworksPerGroup))
+                        if (!collectedItems.TryGetValue(item, out var frameworksPerGroup))
                         {
                             frameworksPerGroup = new HashSet<RegistryTargetFramework>();
-                            collectedItems.Add(closestVersion.Item1, frameworksPerGroup);
+                            collectedItems.Add(item, frameworksPerGroup);
                         }
-                        frameworksPerGroup.Add(closestVersion.Item2);
+                        frameworksPerGroup.Add(targetFramework);
                     }
 
                     if (!packageEntry.Analyzer && collectedItems.Count == 0)
@@ -662,14 +662,17 @@ namespace UnityNuGet
                         }
                     }
 
-                    foreach (var groupToFrameworks in collectedItems)
+                    foreach (var (item, frameworks) in collectedItems)
                     {
-                        var item = groupToFrameworks.Key;
-                        var frameworks = groupToFrameworks.Value;
-
                         var folderPrefix = hasMultiNetStandard ? $"{frameworks.First().Name}/" : "";
                         foreach (var file in item.Items)
                         {
+                            // reject resource dlls since Unity can't use them and we're not handling paths
+                            if (file.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
+                            {
+                                continue;
+                            }
+
                             var fileInUnityPackage = $"{folderPrefix}{Path.GetFileName(file)}";
                             string? meta;
 


### PR DESCRIPTION
I haven't tested it in a player, would it be better to just mark it as editor only?

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Microsoft.CodeAnalysis.CSharp
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [ ] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


