### PR TITLE
Add websocketsharp.core to registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1170,6 +1170,10 @@
     "listed": true,
     "version": "2.3.0"
   },
+  "Websocketsharp.core": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "ZstdSharp.Port": {
     "listed": true,
     "version": "0.5.0"


### PR DESCRIPTION
This PR adds the [websocketsharp.core](https://www.nuget.org/packages/websocketsharp.core) package to the registry.

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/websocketsharp.core
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1) - **version provided: 1.0.0**
> - [x] It must provide .NETStandard2.0 assemblies as part of its package - **version: >= .NETStandard2.0**
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor - **tested in my app in editor**
> - [x] The package has been tested with a Unity standalone player - **tested in a server build**
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR - **no dependencies**
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


