### PR TITLE
Added System.IO.Abstractions and dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1057,6 +1057,14 @@
     "listed": true,
     "version": "3.2.0"
   },
+  "System.IO.Abstractions": {
+    "listed": true,
+    "version": "2.1.0.201"
+  },
+  "System.IO.FileSystem.AccessControl": {
+    "listed": true,
+    "version": "4.5.0"
+  },
   "System.IO.Pipelines": {
     "listed": true,
     "version": "4.5.0"
@@ -1168,6 +1176,14 @@
   "Telnet": {
     "listed": true,
     "version": "0.8.6"
+  },
+  "TestableIO.System.IO.Abstractions": {
+    "listed": true,
+    "version": "18.0.1"
+  },
+  "TestableIO.System.IO.Abstractions.Wrappers": {
+    "listed": true,
+    "version": "18.0.1"
   },
   "UniRxAnalyzer": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1063,7 +1063,7 @@
   },
   "System.IO.FileSystem.AccessControl": {
     "listed": true,
-    "version": "4.5.0"
+    "version": "4.4.0"
   },
   "System.IO.Pipelines": {
     "listed": true,
@@ -1179,11 +1179,11 @@
   },
   "TestableIO.System.IO.Abstractions": {
     "listed": true,
-    "version": "18.0.1"
+    "version": "17.2.26"
   },
   "TestableIO.System.IO.Abstractions.Wrappers": {
     "listed": true,
-    "version": "18.0.1"
+    "version": "17.2.26"
   },
   "UniRxAnalyzer": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/System.IO.Abstractions
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1) - **added: 2.1.0.201, latest: 19.2.29**
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above) - **added System.IO.FileSystem.AccessControl: 4.4.0 and TestableIO.System.IO.Abstractions with .Wrappers: 17.2.26 (these appeared with System.IO.Abstractions: 17.2.26)**
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


