### PR TITLE
Handle nuget packages with per-platform runtimes

### DIFF
--- a/src/UnityNuGet.Tests/PlatformDefinitionTests.cs
+++ b/src/UnityNuGet.Tests/PlatformDefinitionTests.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace UnityNuGet.Tests
+{
+    public class PlatformDefinitionTests
+    {
+        [Test]
+        public void CanFindDefinitions()
+        {
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+
+            // Look-up by OS should return the most general configuration
+            var win = platformDefs.Find(UnityOs.Windows);
+            Assert.IsNotNull(win);
+            Assert.AreEqual(win.Cpu, UnityCpu.AnyCpu);
+
+            // Look-up explicit configuration
+            var win64 = platformDefs.Find(UnityOs.Windows, UnityCpu.X64);
+            Assert.IsNotNull(win64);
+            Assert.AreEqual(win64.Os, win.Os);
+            Assert.AreEqual(win64.Cpu, UnityCpu.X64);
+            Assert.True(win.Children.Contains(win64));
+
+            // Look-up invalid configuration
+            var and = platformDefs.Find(UnityOs.Android, UnityCpu.None);
+            Assert.IsNull(and);
+        }
+
+        [Test]
+        public void RemainingPlatforms_NoneVisited()
+        {
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var visited = new HashSet<PlatformDefinition>();
+
+            // If no platform was visited, the remaining platforms should be the (AnyOS, AnyCPU) config.
+            var remaining = platformDefs.GetRemainingPlatforms(visited);
+            Assert.IsNotNull(remaining);
+            Assert.AreEqual(1, remaining.Count);
+            Assert.AreEqual(remaining.First(), platformDefs);
+        }
+
+        [Test]
+        public void RemainingPlatforms_OneVisited()
+        {
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            
+            foreach (var child in platformDefs.Children)
+            {
+                var visited = new HashSet<PlatformDefinition>() { child };
+                var remaining = platformDefs.GetRemainingPlatforms(visited);
+
+                // We should get all other children, except the one already visited
+                Assert.AreEqual(platformDefs.Children.Count, remaining.Count + 1);
+                foreach (var r in remaining)
+                {
+                    Assert.AreNotEqual(r, child);
+                    Assert.IsTrue(platformDefs.Children.Contains(r));
+                }
+            }
+        }
+
+        [Test]
+        public void RemainingPlatforms_LeafVisited()
+        {
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var win64 = platformDefs.Find(UnityOs.Windows, UnityCpu.X64);
+            var visited = new HashSet<PlatformDefinition>() { win64 };
+
+            // The remaining platforms should be all non-windows, as well as all !x64 windows
+            var expected = platformDefs.Children
+                .Except(new[] { win64.Parent })
+                .Concat(
+                    win64.Parent.Children
+                        .Except(new[] { win64 }))
+                .ToHashSet();
+            var actual = platformDefs.GetRemainingPlatforms(visited);
+            Assert.IsTrue(expected.SetEquals(actual));
+        }
+
+        [TestCase("")]
+        [TestCase("base")]
+        public void TestConfigPath_Root(string basePath)
+        {
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var file = new PlatformFile("a/b/c.dll", platformDefs);
+
+            // We don't use extra paths for the (AnyOS, AnyCPU) configuration
+            var actual = file.GetDestinationPath(basePath);
+            var expected = Path.Combine(
+                basePath,
+                Path.GetFileName(file.SourcePath));
+            Assert.AreEqual(actual, expected);
+        }
+
+        [TestCase("")]
+        [TestCase("base")]
+        public void TestConfigPath_OsOnly(string basePath)
+        {
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var win = platformDefs.Find(UnityOs.Windows);
+            var file = new PlatformFile("a/b/c.dll", win);
+
+            var actual = file.GetDestinationPath(basePath);
+            var expected = Path.Combine(
+                basePath,
+                "Windows",
+                Path.GetFileName(file.SourcePath));
+            Assert.AreEqual(actual, expected);
+        }
+
+        [TestCase("")]
+        [TestCase("base")]
+        public void TestConfigPath_Full(string basePath)
+        {
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var win64 = platformDefs.Find(UnityOs.Windows, UnityCpu.X64);
+            var file = new PlatformFile("a/b/c.dll", win64);
+
+            var actual = file.GetDestinationPath(basePath);
+            var expected = Path.Combine(
+                basePath,
+                "Windows",
+                "x86_64",
+                Path.GetFileName(file.SourcePath));
+            Assert.AreEqual(actual, expected);
+        }
+    }
+}

--- a/src/UnityNuGet.Tests/UnityMetaTests.cs
+++ b/src/UnityNuGet.Tests/UnityMetaTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 
 namespace UnityNuGet.Tests
@@ -87,6 +89,74 @@ namespace UnityNuGet.Tests
             var anyOs = platformDefs.Find(UnityOs.AnyOs, UnityCpu.AnyCpu);
             var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), anyOs, Array.Empty<string>(), new[] { "TEST" });
             StringAssert.DoesNotContain("\r", output);
+        }
+
+        [TestCase(UnityOs.Android, "Android", "Android")]
+        [TestCase(UnityOs.WebGL, "WebGL", "WebGL")]
+        [TestCase(UnityOs.iOS, "iPhone", "iOS")]
+        public void GetMetaForDll_NonEditor(UnityOs os, string platformName, string osName)
+        {
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var output = UnityMeta.GetMetaForDll(
+                Guid.NewGuid(),
+                platformDefs.Find(os),
+                Array.Empty<string>(),
+                Array.Empty<string>());
+
+            // There should be a single 'Exclude Android: 0' match
+            var excludeRegex = new Regex("Exclude (.*): 0");
+            var excludeMatches = excludeRegex.Matches(output);
+            Assert.IsNotNull(excludeMatches);
+            Assert.AreEqual(excludeMatches.Count, 1);
+            Assert.AreEqual(excludeMatches.Single().Groups.Count, 2);
+            Assert.AreEqual(excludeMatches.Single().Groups[1].Value, osName);
+
+            // There should be a single 'enabled: 1' match
+            var enableRegex = new Regex("enabled: 1");
+            var enableMatches = enableRegex.Matches(output);
+            Assert.IsNotNull(enableMatches);
+            Assert.AreEqual(enableMatches.Count, 1);
+
+            StringAssert.Contains($"- first:\n      {platformName}: {osName}\n    second:\n      enabled: 1\n", output);
+        }
+
+        [TestCase(UnityOs.Windows, new[] { "Win", "Win64" })]
+        [TestCase(UnityOs.Linux, new[] { "Linux64" })]
+        [TestCase(UnityOs.OSX, new[] { "OSXUniversal" })]
+        public void GetMetaForDll_Editor(UnityOs os, string[] osNames)
+        {
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var pDef = platformDefs.Find(os);
+            var output = UnityMeta.GetMetaForDll(
+                Guid.NewGuid(),
+                pDef,
+                Array.Empty<string>(),
+                Array.Empty<string>());
+
+            // There should be only 'Exclude Editor: 0' and 'Exclude {{ osName }}: 0' matches
+            var excludeRegex = new Regex("Exclude (.*): 0");
+            var excludeMatches = excludeRegex.Matches(output);
+            Assert.IsNotNull(excludeMatches);
+            var actualExcludes = excludeMatches
+                .Select(match => match.Groups[1].Value)
+                .ToHashSet();
+
+            var expectedExcludes = osNames
+                .Append("Editor")
+                .ToHashSet();
+            Assert.IsTrue(actualExcludes.SetEquals(expectedExcludes));
+
+            // There should be as many 'enabled: 1' matches as exclude matches
+            var enableRegex = new Regex("enabled: 1");
+            var enableMatches = enableRegex.Matches(output);
+            Assert.IsNotNull(enableMatches);
+            Assert.AreEqual(enableMatches.Count, excludeMatches.Count);
+
+            foreach (var osName in actualExcludes)
+            {
+                var platformName = (osName == "Editor") ? osName : "Standalone";
+                StringAssert.Contains($"- first:\n      {platformName}: {osName}\n    second:\n      enabled: 1\n", output);
+            }
         }
     }
 }

--- a/src/UnityNuGet.Tests/UnityMetaTests.cs
+++ b/src/UnityNuGet.Tests/UnityMetaTests.cs
@@ -8,7 +8,9 @@ namespace UnityNuGet.Tests
         [Test]
         public void GetMetaForDll_FormatsDefineConstraintsProperly_WithoutConstraints()
         {
-            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, Array.Empty<string>(), Array.Empty<string>());
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var anyOs = platformDefs.Find(UnityOs.AnyOs, UnityCpu.AnyCpu);
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), anyOs, Array.Empty<string>(), Array.Empty<string>());
             StringAssert.DoesNotContain("defineConstraints", output);
 
             // This is on the same line in the template, so ensure it's intact
@@ -18,7 +20,9 @@ namespace UnityNuGet.Tests
         [Test]
         public void GetMetaForDll_FormatsLabelsProperly_WithoutLabels()
         {
-            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, Array.Empty<string>(), Array.Empty<string>());
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var anyOs = platformDefs.Find(UnityOs.AnyOs, UnityCpu.AnyCpu);
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), anyOs, Array.Empty<string>(), Array.Empty<string>());
             StringAssert.DoesNotContain("labels", output);
 
             // This is on the same line in the template, so ensure it's intact
@@ -30,7 +34,9 @@ namespace UnityNuGet.Tests
         public void GetMetaForDll_FormatsDefineConstraintsProperly_WithConstraints(
             string[] constraints, string expected)
         {
-            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, Array.Empty<string>(), constraints);
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var anyOs = platformDefs.Find(UnityOs.AnyOs, UnityCpu.AnyCpu);
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), anyOs, Array.Empty<string>(), constraints);
 
             StringAssert.Contains(expected, output);
 
@@ -43,7 +49,9 @@ namespace UnityNuGet.Tests
         public void GetMetaForDll_FormatsLabelsProperly_WithLabels(
             string[] labels, string expected)
         {
-            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, labels, Array.Empty<string>());
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var anyOs = platformDefs.Find(UnityOs.AnyOs, UnityCpu.AnyCpu);
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), anyOs, labels, Array.Empty<string>());
 
             StringAssert.Contains(expected, output);
 
@@ -55,7 +63,19 @@ namespace UnityNuGet.Tests
         [TestCase(false, "0")]
         public void GetMetaForDll_FormatsAnyPlatformEnabledProperly(bool value, string expected)
         {
-            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), value, Array.Empty<string>(), Array.Empty<string>());
+            PlatformDefinition platformDef;
+
+            if (value)
+            {
+                var platformDefs = PlatformDefinition.CreateAllPlatforms();
+                platformDef = platformDefs.Find(UnityOs.AnyOs, UnityCpu.AnyCpu);
+            }
+            else
+            {
+                platformDef = new PlatformDefinition(UnityOs.AnyOs, UnityCpu.None, isEditorConfig: false);
+            }
+
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), platformDef, Array.Empty<string>(), Array.Empty<string>());
 
             StringAssert.Contains($"\n  platformData:\n  - first:\n      Any:\n    second:\n      enabled: {expected}\n", output);
         }
@@ -63,7 +83,9 @@ namespace UnityNuGet.Tests
         [Test]
         public void GetMetaForDll_ContainsNoWindowsNewlines()
         {
-            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), true, Array.Empty<string>(), new[] { "TEST" });
+            var platformDefs = PlatformDefinition.CreateAllPlatforms();
+            var anyOs = platformDefs.Find(UnityOs.AnyOs, UnityCpu.AnyCpu);
+            var output = UnityMeta.GetMetaForDll(Guid.NewGuid(), anyOs, Array.Empty<string>(), new[] { "TEST" });
             StringAssert.DoesNotContain("\r", output);
         }
     }

--- a/src/UnityNuGet/NativeLibraries.cs
+++ b/src/UnityNuGet/NativeLibraries.cs
@@ -41,6 +41,7 @@ namespace UnityNuGet
                     "lin" => UnityOs.Linux,
                     "osx" => UnityOs.OSX,
                     "win" => UnityOs.Windows,
+                    "ios" => UnityOs.iOS,
                     _ => null
                 };
 

--- a/src/UnityNuGet/NativeLibraries.cs
+++ b/src/UnityNuGet/NativeLibraries.cs
@@ -5,13 +5,14 @@ using System.Linq;
 using System.Threading;
 using NuGet.Common;
 using NuGet.Packaging;
-using Scriban;
 
 namespace UnityNuGet
 {
     static class NativeLibraries
     {
-        public static async IAsyncEnumerable<(string file, string[] folders, string platform, string architecture)> GetSupportedNativeLibsAsync(PackageReaderBase packageReader, ILogger logger)
+        public static async IAsyncEnumerable<(string file, string[] folders, UnityOs os, UnityCpu cpu)> GetSupportedNativeLibsAsync(
+            PackageReaderBase packageReader,
+            ILogger logger)
         {
             var versions = await packageReader.GetItemsAsync(PackagingConstants.Folders.Runtimes, CancellationToken.None);
             var files = versions.SelectMany(v => v.Items);
@@ -35,144 +36,36 @@ namespace UnityNuGet
                     continue;
                 }
 
-                var platform = system[0][..3] switch
+                UnityOs? os = system[0][..3] switch
                 {
-                    "lin" => "Linux",
-                    "osx" => "OSX",
-                    "win" => "Windows",
+                    "lin" => UnityOs.Linux,
+                    "osx" => UnityOs.OSX,
+                    "win" => UnityOs.Windows,
                     _ => null
                 };
 
-                if (platform is null)
+                if (os is null)
                 {
-                    logger.LogInformation($"Skipping file for unsupported platform: {file} ...");
+                    logger.LogInformation($"Skipping file for unsupported OS: {file} ...");
                     continue;
                 }
 
-                var architecture = system[1] switch
+                UnityCpu? cpu = system[1] switch
                 {
-                    "x86" => "x86",
-                    "x64" => "x86_64",
-                    "arm64" => "ARM64",
+                    "x86" => UnityCpu.X86,
+                    "x64" => UnityCpu.X64,
+                    "arm64" => UnityCpu.ARM64,
                     _ => null
                 };
 
-                if (architecture is null)
+                if (cpu is null)
                 {
-                    logger.LogInformation($"Skipping file for unsupported architecture: {file} ...");
+                    logger.LogInformation($"Skipping file for unsupported CPU: {file} ...");
                     continue;
                 }
 
-                yield return (file, folders, platform, architecture);
+                yield return (file, folders, os.Value, cpu.Value);
             }
-        }
-
-        private readonly struct PlatformEnables
-        {
-            public readonly int Editor, Linux64, OSXUniversal, Win, Win64;
-
-            public PlatformEnables(int editor, int linux64, int oSXUniversal, int win, int win64)
-            {
-                Editor = editor;
-                Linux64 = linux64;
-                OSXUniversal = oSXUniversal;
-                Win = win;
-                Win64 = win64;
-            }
-        }
-
-        public static string? GetMetaForNative(Guid guid, string platform, string architecture, string[] labels)
-        {
-            // TODO: Support other platforms
-            PlatformEnables? enables = (platform, architecture) switch
-            {
-                ("Linux", _) => new(1, 1, 0, 0, 0),
-                ("OSX", _) => new(1, 0, 1, 0, 0),
-                ("Windows", "x86") => new(0, 0, 0, 1, 0),
-                ("Windows", "x86_64") => new(1, 0, 0, 0, 1),
-                _ => null,
-            };
-
-            if (enables is null) return null;
-
-            const string text = @"{{ cpu(x) = x == 1 ? architecture : ""None"" }}fileFormatVersion: 2
-guid: {{ guid }}
-{{ labels }}PluginImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  iconMap: {}
-  executionOrder: {}
-  defineConstraints: []
-  isPreloaded: 0
-  isOverridable: 0
-  isExplicitlyReferenced: 0
-  validateReferences: 1
-  platformData:
-  - first:
-      : Any
-    second:
-      enabled: 0
-      settings:
-        Exclude Editor: {{ 1 - enables.Editor }}
-        Exclude Linux64: {{ 1 - enables.Linux64 }}
-        Exclude OSXUniversal: {{ 1 - enables.OSXUniversal }}
-        Exclude Win: {{ 1 - enables.Win }}
-        Exclude Win64: {{ 1 - enables.Win64 }}
-  - first:
-      Any: 
-    second:
-      enabled: 1
-      settings: {}
-  - first:
-      Editor: Editor
-    second:
-      enabled: {{ enables.Editor }}
-      settings:
-        CPU: {{ cpu enables.Editor }}
-        DefaultValueInitialized: true
-        OS: {{ enables.Editor == 1 ? platform : ""None"" }}
-  - first:
-      Standalone: Linux64
-    second:
-      enabled: {{ enables.Linux64 }}
-      settings:
-        CPU: {{ cpu enables.Linux64 }}
-  - first:
-      Standalone: OSXUniversal
-    second:
-      enabled: {{ enables.OSXUniversal }}
-      settings:
-        CPU: {{ cpu enables.OSXUniversal }}
-  - first:
-      Standalone: Win
-    second:
-      enabled: {{ enables.Win }}
-      settings:
-        CPU: {{ cpu enables.Win }}
-  - first:
-      Standalone: Win64
-    second:
-      enabled: {{ enables.Win64 }}
-      settings:
-        CPU: {{ cpu enables.Win64 }}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
-";
-
-            return Template
-                .Parse(text)
-                .Render(new
-                {
-                    guid = guid.ToString("N"),
-                    enables,
-                    platform,
-                    architecture,
-                    labels = labels.Length == 0
-                    ? string.Empty
-                    : $"labels:\n{string.Concat(labels.Select(l => $"  - {l}\n"))}",
-                })
-                .Replace("\r\n", "\n");
         }
     }
 }

--- a/src/UnityNuGet/PlatformDefinition.cs
+++ b/src/UnityNuGet/PlatformDefinition.cs
@@ -1,0 +1,306 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace UnityNuGet
+{
+    internal enum UnityOs
+    {
+        AnyOs,
+        Windows,
+        Linux,
+        OSX,
+        Android,
+        WebGL
+    }
+
+    internal enum UnityCpu
+    {
+        AnyCpu,
+        X64,
+        X86,
+        ARM64,
+        ARMv7,
+        None,
+    }
+
+    internal static class UnityEnumExtensions
+    {
+        public static string GetPathName(this UnityOs os)
+        {
+            return os switch
+            {
+                UnityOs.AnyOs => string.Empty,
+                _ => GetName(os),
+            };
+        }
+
+        public static string GetName(this UnityOs os)
+        {
+            return os switch
+            {
+                UnityOs.AnyOs => "AnyOS",
+                UnityOs.Windows => "Windows",
+                UnityOs.Linux => "Linux",
+                UnityOs.OSX => "OSX",
+                UnityOs.Android => "Android",
+                UnityOs.WebGL => "WebGL",
+                _ => throw new ArgumentException($"Unknown OS {os}"),
+            };
+        }
+
+        public static string GetPathName(this UnityCpu cpu)
+        {
+            return cpu switch
+            {
+                UnityCpu.AnyCpu => string.Empty,
+                _ => GetName(cpu),
+            };
+        }
+
+        public static string GetName(this UnityCpu cpu)
+        {
+            return cpu switch
+            {
+                UnityCpu.AnyCpu => "AnyCPU",
+                UnityCpu.X64 => "x86_64",
+                UnityCpu.X86 => "x86",
+                UnityCpu.ARM64 => "ARM64",
+                UnityCpu.ARMv7 => "ARMv7",
+                UnityCpu.None => "None",
+                _ => throw new ArgumentException($"Unknown CPU {cpu}"),
+            };
+        }
+    }
+
+    internal class PlatformDefinition
+    {
+        private readonly UnityOs _os;
+        private readonly UnityCpu _cpu;
+        private readonly bool _isEditor;
+        private readonly List<PlatformDefinition> _children;
+
+        private PlatformDefinition? _parent;
+
+        public PlatformDefinition(UnityOs os, UnityCpu cpu, bool isEditorConfig)
+        {
+            _os = os;
+            _cpu = cpu;
+            _parent = null;
+            _children = new();
+            _isEditor = isEditorConfig;
+        }
+
+        public PlatformDefinition? Parent
+        {
+            get => _parent;
+
+            private set
+            {
+                _parent = value;
+            }
+        }
+
+        public IReadOnlyList<PlatformDefinition> Children
+        {
+            get => _children;
+
+            private set
+            {
+                _children.AddRange(value);
+
+                foreach (var child in _children)
+                {
+                    child.Parent = this;
+                }
+            }
+        }
+
+        public int Depth
+            => (_parent == null) ? 0 : (1 + _parent.Depth);
+
+        public UnityOs Os
+            => _os;
+
+        public UnityCpu Cpu
+            => _cpu;
+
+        public override string ToString()
+            => $"{_os}.{_cpu}";
+
+        public PlatformDefinition? Find(UnityOs os, UnityCpu cpu)
+        {
+            // Test self
+            if ((_os == os) && (_cpu == cpu))
+            {
+                return this;
+            }
+
+            // Recurse to children
+            return _children
+                .Select(c => c.Find(os, cpu))
+                .Where(c => c != null)
+                .FirstOrDefault();
+        }
+
+        public PlatformDefinition? Find(UnityOs os)
+        {
+            // Test self
+            if (_os == os)
+            {
+                return this;
+            }
+
+            // Recurse to children
+            return _children
+                .Select(c => c.Find(os))
+                .Where(c => c != null)
+                .FirstOrDefault();
+        }
+
+        public PlatformDefinition? FindEditor()
+        {
+            // Test self
+            if (_isEditor)
+            {
+                return this;
+            }
+
+            // Recurse to children
+            return _children
+                .Select(c => c.FindEditor())
+                .Where(c => c != null)
+                .FirstOrDefault();
+        }
+
+        public HashSet<PlatformDefinition> GetRemainingPlatforms(IReadOnlySet<PlatformDefinition> visitedPlatforms)
+        {
+            var remainingPlatforms = new HashSet<PlatformDefinition>
+            {
+                // Push the root
+                this
+            };
+
+            for (bool found = true; found;)
+            {
+                found = false;
+
+                foreach (var p in remainingPlatforms)
+                {
+                    // Remove p if already visited
+                    if (visitedPlatforms.Contains(p))
+                    {
+                        remainingPlatforms.Remove(p);
+                        found = true;
+                        break;
+                    }
+
+                    // If p has descendants that were visited, we can't use it and need to expand it
+                    if (p.HasVisitedDescendants(visitedPlatforms))
+                    {
+                        remainingPlatforms.Remove(p);
+
+                        foreach (var c in p.Children)
+                        {
+                            remainingPlatforms.Add(c);
+                        }
+
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            return remainingPlatforms;
+        }
+
+        public static PlatformDefinition CreateAllPlatforms()
+        {
+            var root = new PlatformDefinition(UnityOs.AnyOs, UnityCpu.AnyCpu, isEditorConfig: true)
+            {
+                Children = new List<PlatformDefinition>()
+                {
+                    new PlatformDefinition(UnityOs.Windows, UnityCpu.AnyCpu, isEditorConfig: true)
+                    {
+                        Children = new List<PlatformDefinition>()
+                        {
+                            new PlatformDefinition(UnityOs.Windows, UnityCpu.X64, isEditorConfig: true),
+                            new PlatformDefinition(UnityOs.Windows, UnityCpu.X86, isEditorConfig: false),
+                        },
+                    },
+                    new PlatformDefinition(UnityOs.Linux, UnityCpu.X64, isEditorConfig: true),
+                    new PlatformDefinition(UnityOs.Android, UnityCpu.ARMv7, isEditorConfig: false),
+                    new PlatformDefinition(UnityOs.WebGL, UnityCpu.AnyCpu, isEditorConfig: false),
+                    new PlatformDefinition(UnityOs.OSX, UnityCpu.AnyCpu, isEditorConfig: true)
+                    {
+                        Children = new List<PlatformDefinition>()
+                        {
+                            new PlatformDefinition(UnityOs.OSX, UnityCpu.X64, isEditorConfig: true),
+                            new PlatformDefinition(UnityOs.OSX, UnityCpu.ARM64, isEditorConfig: true),
+                        },
+                    }
+                }
+            };
+
+            return root;
+        }
+
+        private bool HasVisitedDescendants(IReadOnlySet<PlatformDefinition> visitedPlatforms)
+        {
+            if (visitedPlatforms.Contains(this))
+            {
+                return true;
+            }
+
+            foreach (var c in _children)
+            {
+                if (c.HasVisitedDescendants(visitedPlatforms))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    internal class PlatformFile
+    {
+        private readonly PlatformDefinition _platform;
+        private readonly string _sourcePath;
+
+        public PlatformFile(string sourcePath, PlatformDefinition platform)
+        {
+            _sourcePath = sourcePath;
+            _platform = platform;
+        }
+
+        public string SourcePath
+            => _sourcePath;
+
+        public PlatformDefinition Platform
+            => _platform;
+
+        public string GetDestinationPath(string basePath)
+        {
+            var fullPath = basePath;
+            var depth = _platform.Depth;
+
+            if (depth > 0)
+            {
+                fullPath = Path.Combine(fullPath, _platform.Os.GetPathName());
+            }
+
+            if (depth > 1)
+            {
+                fullPath = Path.Combine(fullPath, _platform.Cpu.GetPathName());
+            }
+
+            var fileName = Path.GetFileName(_sourcePath);
+            fullPath = Path.Combine(fullPath, fileName);
+            return fullPath;
+        }
+    }
+}

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -693,7 +693,8 @@ namespace UnityNuGet
                             var platformDef = platformDefs.Find(os, cpu);
                             if (platformDef == null)
                             {
-                                LogError($"Failed to find a platform definition for: {os}, {cpu}");
+                                LogInformation($"Failed to find a platform definition for: {os}, {cpu}");
+                                continue;
                             }
 
                             // We have a platform, add this file to the set of files to write
@@ -796,7 +797,8 @@ namespace UnityNuGet
                         var platformDef = platformDefs.Find(os, cpu);
                         if (platformDef == null)
                         {
-                            LogError($"Failed to find a platform definition for: {os}, {cpu}");
+                            LogInformation($"Failed to find a platform definition for: {os}, {cpu}");
+                            continue;
                         }
 
                         string extension = Path.GetExtension(file);

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -33,7 +33,7 @@ namespace UnityNuGet
         public static readonly bool IsRunningOnAzure = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"));
         
         // Change this version number if the content of the packages are changed by an update of this class
-        private const string CurrentRegistryVersion = "1.5.0";
+        private const string CurrentRegistryVersion = "1.6.0";
 
         private static readonly Encoding Utf8EncodingNoBom = new UTF8Encoding(false, false);
         private readonly string _rootPersistentFolder;
@@ -682,7 +682,7 @@ namespace UnityNuGet
 
                         // Mark-up the platforms of all runtime libraries
                         var runtimePlatforms = new HashSet<PlatformDefinition>();
-                        foreach (var (file, folders, os, cpu) in runtimeLibs)
+                        foreach (var (file, os, cpu) in runtimeLibs)
                         {
                             // Reject resource dlls since Unity can't use them and we're not handling paths
                             if (file.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -639,7 +639,11 @@ namespace UnityNuGet
                             string fileExtension = Path.GetExtension(fileInUnityPackage);
                             if (fileExtension == ".dll")
                             {
-                                meta = UnityMeta.GetMetaForDll(GetStableGuid(identity, fileInUnityPackage), false, new string[] { "RoslynAnalyzer" }, Array.Empty<string>());
+                                meta = UnityMeta.GetMetaForDll(
+                                    GetStableGuid(identity, fileInUnityPackage),
+                                    new PlatformDefinition(UnityOs.AnyOs, UnityCpu.None, isEditorConfig: false),
+                                    new string[] { "RoslynAnalyzer" },
+                                    Array.Empty<string>());
                             }
                             else
                             {
@@ -666,18 +670,78 @@ namespace UnityNuGet
                         }
                     }
 
+                    // Get all known platform definitions
+                    var platformDefs = PlatformDefinition.CreateAllPlatforms();
+                    var packageFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
                     foreach (var (item, frameworks) in collectedItems)
                     {
                         var folderPrefix = hasMultiNetStandard ? $"{frameworks.First().Name}/" : "";
-                        foreach (var file in item.Items)
+                        var filesToWrite = new List<PlatformFile>();
+
+                        // Get any available runtime library groups
+                        var runtimeLibs = await RuntimeLibraries
+                            .GetSupportedRuntimeLibsAsync(packageReader, item.TargetFramework, _logger)
+                            .ToListAsync();
+
+                        // Mark-up the platforms of all runtime libraries
+                        var runtimePlatforms = new HashSet<PlatformDefinition>();
+                        foreach (var (file, folders, os, cpu) in runtimeLibs)
                         {
-                            // reject resource dlls since Unity can't use them and we're not handling paths
+                            // Reject resource dlls since Unity can't use them and we're not handling paths
                             if (file.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
                             {
                                 continue;
                             }
 
-                            var fileInUnityPackage = $"{folderPrefix}{Path.GetFileName(file)}";
+                            var platformDef = platformDefs.Find(os, cpu);
+                            if (platformDef == null)
+                            {
+                                LogError($"Failed to find a platform definition for: {os}, {cpu}");
+                            }
+
+                            // We have a platform, add this file to the set of files to write
+                            runtimePlatforms.Add(platformDef!);
+                            filesToWrite.Add(new PlatformFile(file, platformDef!));
+                        }
+
+                        // Compute the set of platforms covered by the lib dlls
+                        var libPlatforms = platformDefs.GetRemainingPlatforms(runtimePlatforms);
+
+                        // Add the lib files
+                        foreach (var libPlatform in libPlatforms)
+                        {
+                            foreach (var file in item.Items)
+                            {
+                                // Reject resource dlls since Unity can't use them and we're not handling paths
+                                if (file.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    continue;
+                                }
+
+                                filesToWrite.Add(new PlatformFile(file, libPlatform));
+                            }
+                        }
+
+                        // Write the files
+                        foreach (var file in filesToWrite)
+                        {
+                            // Get the destination path
+                            var fileInUnityPackage = file.GetDestinationPath(folderPrefix);
+
+                            // Collect the folders' metas
+                            {
+                                string? fullPath = Path.GetDirectoryName(fileInUnityPackage);
+                                string[] folders = fullPath?.Split(Path.DirectorySeparatorChar) ?? Array.Empty<string>();
+                                string folder = string.Empty;
+
+                                foreach (var relative in folders)
+                                {
+                                    folder = Path.Combine(folder, relative);
+                                    packageFolders.Add(folder);
+                                }
+                            }
+
                             string? meta;
 
                             string fileExtension = Path.GetExtension(fileInUnityPackage);
@@ -688,8 +752,15 @@ namespace UnityNuGet
                                 // We will use the define coming from the configuration file
                                 // Otherwise, it means that the assembly is compatible with whatever netstandard, and we can simply
                                 // use NET_STANDARD
-                                var defineConstraints = hasMultiNetStandard || hasOnlyNetStandard21 || isPackageNetStandard21Assembly ? frameworks.First(x => x.Framework == item.TargetFramework).DefineConstraints : Array.Empty<string>();
-                                meta = UnityMeta.GetMetaForDll(GetStableGuid(identity, fileInUnityPackage), true, Array.Empty<string>(), defineConstraints != null ? defineConstraints.Concat(packageEntry.DefineConstraints) : Array.Empty<string>());
+                                var defineConstraints = hasMultiNetStandard
+                                    || hasOnlyNetStandard21
+                                    || isPackageNetStandard21Assembly ? frameworks.First(x => x.Framework == item.TargetFramework).DefineConstraints : Array.Empty<string>();
+
+                                meta = UnityMeta.GetMetaForDll(
+                                    GetStableGuid(identity, fileInUnityPackage),
+                                    file.Platform,
+                                    Array.Empty<string>(),
+                                    defineConstraints != null ? defineConstraints.Concat(packageEntry.DefineConstraints) : Array.Empty<string>());
                             }
                             else
                             {
@@ -704,7 +775,7 @@ namespace UnityNuGet
                             memStream.Position = 0;
                             memStream.SetLength(0);
 
-                            using var stream = await packageReader.GetStreamAsync(file, CancellationToken.None);
+                            using var stream = await packageReader.GetStreamAsync(file.SourcePath, CancellationToken.None);
                             await stream.CopyToAsync(memStream);
                             var buffer = memStream.ToArray();
 
@@ -713,13 +784,6 @@ namespace UnityNuGet
 
                             // write meta file
                             await WriteTextFileToTar(tarArchive, $"{fileInUnityPackage}.meta", meta);
-                        }
-
-                        // Write folder meta
-                        if (!string.IsNullOrEmpty(folderPrefix) && item.Items.Any())
-                        {
-                            // write meta file for the folder
-                            await WriteTextFileToTar(tarArchive, $"{folderPrefix[0..^1]}.meta", UnityMeta.GetMetaForFolder(GetStableGuid(identity, folderPrefix)));
                         }
                     }
 
@@ -730,15 +794,20 @@ namespace UnityNuGet
 
                     // Write the native libraries
                     var nativeFiles = NativeLibraries.GetSupportedNativeLibsAsync(packageReader, _logger);
-                    var nativeFolders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                    await foreach (var (file, folders, platform, architecture) in nativeFiles)
+                    await foreach (var (file, folders, os, cpu) in nativeFiles)
                     {
+                        var platformDef = platformDefs.Find(os, cpu);
+                        if (platformDef == null)
+                        {
+                            LogError($"Failed to find a platform definition for: {os}, {cpu}");
+                        }
+
                         string extension = Path.GetExtension(file);
                         var guid = GetStableGuid(identity, file);
                         string? meta = extension switch
                         {
-                            ".dll" or ".so" or ".dylib" => NativeLibraries.GetMetaForNative(guid, platform, architecture, Array.Empty<string>()),
+                            ".dll" or ".so" or ".dylib" => UnityMeta.GetMetaForDll(guid, platformDef!, Array.Empty<string>(), Array.Empty<string>()),
                             _ => UnityMeta.GetMetaForExtension(guid, extension)
                         };
 
@@ -757,16 +826,16 @@ namespace UnityNuGet
                         await WriteTextFileToTar(tarArchive, $"{file}.meta", meta);
 
                         // Remember all folders for meta files
-                        string folder = "";
+                        string folder = string.Empty;
 
                         foreach (var relative in folders)
                         {
                             folder = Path.Combine(folder, relative);
-                            nativeFolders.Add(folder);
+                            packageFolders.Add(folder);
                         }
                     }
 
-                    foreach (var folder in nativeFolders)
+                    foreach (var folder in packageFolders)
                     {
                         await WriteTextFileToTar(tarArchive, $"{folder}.meta", UnityMeta.GetMetaForFolder(GetStableGuid(identity, folder)));
                     }

--- a/src/UnityNuGet/RegistryEntry.cs
+++ b/src/UnityNuGet/RegistryEntry.cs
@@ -15,9 +15,6 @@ namespace UnityNuGet
         [JsonProperty("listed")]
         public bool Listed { get; set; }
 
-        [JsonProperty("scope")]
-        public string? UnityScope { get; set; }
-
         [JsonProperty("version")]
         public VersionRange? Version { get; set; }
 

--- a/src/UnityNuGet/RegistryEntry.cs
+++ b/src/UnityNuGet/RegistryEntry.cs
@@ -15,6 +15,9 @@ namespace UnityNuGet
         [JsonProperty("listed")]
         public bool Listed { get; set; }
 
+        [JsonProperty("scope")]
+        public string? UnityScope { get; set; }
+
         [JsonProperty("version")]
         public VersionRange? Version { get; set; }
 

--- a/src/UnityNuGet/RuntimeLibraries.cs
+++ b/src/UnityNuGet/RuntimeLibraries.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+
+namespace UnityNuGet
+{
+    static class RuntimeLibraries
+    {
+        public static async IAsyncEnumerable<(string file, string[] folders, UnityOs, UnityCpu)> GetSupportedRuntimeLibsAsync(
+            PackageReaderBase packageReader,
+            NuGetFramework targetFramework,
+            ILogger logger)
+        {
+            var versions = await packageReader.GetItemsAsync(PackagingConstants.Folders.Runtimes, CancellationToken.None);
+            var files = versions.SelectMany(v => v.Items);
+
+            foreach (var file in files)
+            {
+                var folderPath = Path.GetDirectoryName(file)!;
+                var folders = folderPath.Split(Path.DirectorySeparatorChar);
+
+                if (folders.Length != 4 || !folders[2].Equals("lib", StringComparison.OrdinalIgnoreCase))
+                {
+                    logger.LogInformation($"Skipping native library file located in the runtimes folder: {file} ...");
+                    continue;
+                }
+
+                var framework = NuGetFramework.Parse(folders[3]);
+                if (framework != targetFramework)
+                {
+                    logger.LogInformation($"Skipping runtime library targeting other frameworks: {file} ...");
+                    continue;
+                }
+
+                var system = folders[1].Split('-');
+
+                if (system.Length < 1)
+                {
+                    logger.LogInformation($"Skipping file located in the runtime folder that does not specify platform: {file} ...");
+                    continue;
+                }
+
+                UnityOs? os = system[0][..3] switch
+                {
+                    "lin" => UnityOs.Linux,
+                    "osx" => UnityOs.OSX,
+                    "win" => UnityOs.Windows,
+                    _ => null
+                };
+
+                if (os is null)
+                {
+                    logger.LogInformation($"Skipping runtime library for unsupported OS: {file} ...");
+                    continue;
+                }
+
+                UnityCpu? cpu = UnityCpu.AnyCpu;
+                if (system.Length > 1)
+                {
+                    cpu = system[1] switch
+                    {
+                        "x86" => UnityCpu.X86,
+                        "x64" => UnityCpu.X64,
+                        "arm64" => UnityCpu.ARM64,
+                        _ => null
+                    };
+
+                    if (cpu is null)
+                    {
+                        logger.LogInformation($"Skipping runtime library for unsupported CPU: {file} ...");
+                        continue;
+                    }
+                }
+
+                yield return (file, folders, os.Value, cpu.Value);
+            }
+        }
+    }
+}

--- a/src/UnityNuGet/UnityMeta.cs
+++ b/src/UnityNuGet/UnityMeta.cs
@@ -87,6 +87,7 @@ guid: {{ guid }}
                 var platOsx = platformDef.Find(UnityOs.OSX);
                 var platAndroid = platformDef.Find(UnityOs.Android);
                 var platWasm = platformDef.Find(UnityOs.WebGL);
+                var platIos = platformDef.Find(UnityOs.iOS);
                 var platEditor = platformDef.FindEditor();
 
                 var dict = new
@@ -97,6 +98,7 @@ guid: {{ guid }}
                     enablesOsx = (platOsx != null) ? 1 : 0,
                     enablesAndroid = (platAndroid != null) ? 1 : 0,
                     enablesWasm = (platWasm != null) ? 1 : 0,
+                    enablesIos = (platIos != null) ? 1 : 0,
                     enablesEditor = (platEditor != null) ? 1 : 0,
 
                     cpuWin = (platWin?.Cpu ?? UnityCpu.None).GetName(),
@@ -104,6 +106,7 @@ guid: {{ guid }}
                     cpuLinux64 = (platLinux64?.Cpu ?? UnityCpu.None).GetName(),
                     cpuOsx = (platOsx?.Cpu ?? UnityCpu.None).GetName(),
                     cpuAndroid = (platAndroid?.Cpu ?? UnityCpu.None).GetName(),
+                    cpuIos = (platIos?.Cpu ?? UnityCpu.None).GetName(),
                     cpuEditor = (platEditor?.Cpu ?? UnityCpu.None).GetName(),
 
                     osEditor = (platEditor?.Os ?? UnityOs.AnyOs).GetName(),
@@ -121,7 +124,8 @@ guid: {{ guid }}
         Exclude OSXUniversal: {{ 1 - enables_osx }}
         Exclude WebGL: {{ 1 - enables_wasm }}
         Exclude Win: {{ 1 - enables_win }}
-        Exclude Win64: {{ 1 - enables_win64 }}";
+        Exclude Win64: {{ 1 - enables_win64 }}
+        Exclude iOS: {{ 1 - enables_ios }}";
 
                 const string perPlatformSettingsText = @"
   - first:
@@ -166,7 +170,16 @@ guid: {{ guid }}
       WebGL: WebGL
     second:
       enabled: {{ enables_wasm }}
-      settings: {}";
+      settings: {}
+  - first:
+      iPhone: iOS
+    second:
+      enabled: {{ enables_ios }}
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: {{ cpu_ios }}
+        CompileFlags: 
+        FrameworkDependencies: ";
 
                 excludePlatforms = Template
                     .Parse(excludePlatformsText)

--- a/src/UnityNuGet/UnityMeta.cs
+++ b/src/UnityNuGet/UnityMeta.cs
@@ -27,7 +27,11 @@ namespace UnityNuGet
             return null;
         }
 
-        public static string GetMetaForDll(Guid guid, bool anyPlatformEnabled, IEnumerable<string> labels, IEnumerable<string> defineConstraints)
+        public static string GetMetaForDll(
+            Guid guid,
+            PlatformDefinition platformDef,
+            IEnumerable<string> labels,
+            IEnumerable<string> defineConstraints)
         {
             const string text = @"fileFormatVersion: 2
 guid: {{ guid }}
@@ -40,18 +44,12 @@ guid: {{ guid }}
   isOverridable: 0
   isExplicitlyReferenced: 0
   validateReferences: 1
-  platformData:
+  platformData:{{exclude_platforms}}
   - first:
       Any:
     second:
-      enabled: {{ enabled }}
-      settings: {}
-  - first:
-      Editor: Editor
-    second:
-      enabled: 0
-      settings:
-        DefaultValueInitialized: true
+      enabled: {{ all_enabled }}
+      settings: {}{{ per_platform_settings }}
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
@@ -70,12 +68,125 @@ guid: {{ guid }}
                 string.Empty,
                 items.Select(d => $"  - {d}\n"));
 
+            string excludePlatforms = string.Empty;
+            string perPlatformSettings = @"
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true";
+
+            // Render the per-platform settings
+            if (platformDef.Os != UnityOs.AnyOs)
+            {
+                // Determine which configurations are enabled
+                var platWin = platformDef.Find(UnityOs.Windows, UnityCpu.X86);
+                var platWin64 = platformDef.Find(UnityOs.Windows, UnityCpu.X64);
+                var platLinux64 = platformDef.Find(UnityOs.Linux, UnityCpu.X64);
+                var platOsx = platformDef.Find(UnityOs.OSX);
+                var platAndroid = platformDef.Find(UnityOs.Android);
+                var platWasm = platformDef.Find(UnityOs.WebGL);
+                var platEditor = platformDef.FindEditor();
+
+                var dict = new
+                {
+                    enablesWin = (platWin != null) ? 1 : 0,
+                    enablesWin64 = (platWin64 != null) ? 1 : 0,
+                    enablesLinux64 = (platLinux64 != null) ? 1 : 0,
+                    enablesOsx = (platOsx != null) ? 1 : 0,
+                    enablesAndroid = (platAndroid != null) ? 1 : 0,
+                    enablesWasm = (platWasm != null) ? 1 : 0,
+                    enablesEditor = (platEditor != null) ? 1 : 0,
+
+                    cpuWin = (platWin?.Cpu ?? UnityCpu.None).GetName(),
+                    cpuWin64 = (platWin64?.Cpu ?? UnityCpu.None).GetName(),
+                    cpuLinux64 = (platLinux64?.Cpu ?? UnityCpu.None).GetName(),
+                    cpuOsx = (platOsx?.Cpu ?? UnityCpu.None).GetName(),
+                    cpuAndroid = (platAndroid?.Cpu ?? UnityCpu.None).GetName(),
+                    cpuEditor = (platEditor?.Cpu ?? UnityCpu.None).GetName(),
+
+                    osEditor = (platEditor?.Os ?? UnityOs.AnyOs).GetName(),
+                };
+
+                const string excludePlatformsText = @"
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: {{ 1 - enables_android }}
+        Exclude Editor: {{ 1 - enables_editor }}
+        Exclude Linux64: {{ 1 - enables_linux64 }}
+        Exclude OSXUniversal: {{ 1 - enables_osx }}
+        Exclude WebGL: {{ 1 - enables_wasm }}
+        Exclude Win: {{ 1 - enables_win }}
+        Exclude Win64: {{ 1 - enables_win64 }}";
+
+                const string perPlatformSettingsText = @"
+  - first:
+      Android: Android
+    second:
+      enabled: {{ enables_android }}
+      settings:
+        CPU: {{ cpu_android }}
+  - first:
+      Editor: Editor
+    second:
+      enabled: {{ enables_editor }}
+      settings:
+        CPU: {{ cpu_editor }}
+        DefaultValueInitialized: true
+        OS: {{ os_editor }}
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: {{ enables_linux64 }}
+      settings:
+        CPU: {{ cpu_linux64 }}
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: {{ enables_osx }}
+      settings:
+        CPU: {{ cpu_osx }}
+  - first:
+      Standalone: Win
+    second:
+      enabled: {{ enables_win }}
+      settings:
+        CPU: {{ cpu_win }}
+  - first:
+      Standalone: Win64
+    second:
+      enabled: {{ enables_win64 }}
+      settings:
+        CPU: {{ cpu_win64 }}
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: {{ enables_wasm }}
+      settings: {}";
+
+                excludePlatforms = Template
+                    .Parse(excludePlatformsText)
+                    .Render(dict);
+
+                perPlatformSettings = Template
+                    .Parse(perPlatformSettingsText)
+                    .Render(dict);
+            }
+
+            bool allPlatformsEnabled = (platformDef.Os == UnityOs.AnyOs) && (platformDef.Cpu == UnityCpu.AnyCpu);
+
             return Template
                 .Parse(text)
                 .Render(new
                 {
+                    excludePlatforms,
+                    perPlatformSettings,
                     guid = guid.ToString("N"),
-                    enabled = anyPlatformEnabled ? "1" : "0",
+                    allEnabled = allPlatformsEnabled ? "1" : "0",
                     labels = allLabels.Count == 0
                         ? string.Empty
                         : $"labels:\n{FormatList(allLabels)}",


### PR DESCRIPTION
This PR fixes #221 
- Added a `PlatformDefinition` class as a replacement for the  `PlatformEnables` in `NativeLibraries`.
- Unified the meta files for the lib and native dlls.
- Added Android and WebGL to the dll meta files.
- Dlls in nuget packages that have `runtimes` folders compatible with the framework that's getting pulled into UPM are also written into the UPM. In this  case, the dlls in the `lib` folder continue to be written into the UPM, but only for the platforms / architectures not covered by the `runtimes` dlls.



