### PR TITLE
Reproducible NPM packages

### DIFF
--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -31,9 +31,9 @@ namespace UnityNuGet
     public class RegistryCache
     {
         public static readonly bool IsRunningOnAzure = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"));
-        
+
         // Change this version number if the content of the packages are changed by an update of this class
-        private const string CurrentRegistryVersion = "1.6.0";
+        private const string CurrentRegistryVersion = "1.7.0";
 
         private static readonly Encoding Utf8EncodingNoBom = new UTF8Encoding(false, false);
         private readonly string _rootPersistentFolder;
@@ -209,7 +209,7 @@ namespace UnityNuGet
                 // Clear the cache entirely
                 _npmPackageRegistry.Reset();
             }
-            
+
             var regexFilter = Filter != null ? new Regex(Filter, RegexOptions.IgnoreCase) : null;
             if (Filter != null)
             {
@@ -1103,7 +1103,7 @@ namespace UnityNuGet
             var hash = SHA1.HashData(inputBytes);
             Array.Copy(hash, 0, guid, 0, guid.Length);
 
-            // Follow UUID for SHA1 based GUID 
+            // Follow UUID for SHA1 based GUID
             const int version = 5; // SHA1 (3 for MD5)
             guid[6] = (byte)((guid[6] & 0x0F) | (version << 4));
             guid[8] = (byte)((guid[8] & 0x3F) | 0x80);

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -1062,6 +1062,7 @@ namespace UnityNuGet
             filePath = filePath.TrimStart('/');
 
             var tarEntry = TarEntry.CreateTarEntry($"package/{filePath}");
+            tarEntry.ModTime = DateTime.UnixEpoch;
             tarEntry.Size = buffer.Length;
             await tarOut.PutNextEntryAsync(tarEntry, cancellationToken);
             await tarOut.WriteAsync(buffer, cancellationToken);

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -554,7 +554,10 @@ namespace UnityNuGet
                 using var memStream = new MemoryStream();
 
                 using (var outStream = File.Create(unityPackageFilePath))
-                using (var gzoStream = new GZipOutputStream(outStream))
+                using (var gzoStream = new GZipOutputStream(outStream)
+                {
+                    ModifiedTime = DateTime.UnixEpoch
+                })
                 using (var tarArchive = new TarOutputStream(gzoStream, Encoding.UTF8))
                 {
                     // Select the framework version that is the closest or equal to the latest configured framework version


### PR DESCRIPTION
Current realization regenerates packages differently on each update.
That creates some issues with NPM caching (verdaccio) & cdn because there is no way to match index.json with pkg sha.

The issue has 2 sources, one is a different mtime for each tar entry because on object creation it uses the current time.
GZip headers encode 4 byte timestamp in the first 10 bytes of an archive. So even if tar is reproducible, gzip is not.
The last step then is to set gzip timestamp to some value.

P.S.
Personally, I don't like set all timestamps to 0, but otherwise, there is a source of stable time needed.
Maybe some Nuget metadata of the converted package?

P.S. 2
Use publishTime of package