### PR TITLE
Support empty dependencyGroups

### DIFF
--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -289,8 +289,15 @@ namespace UnityNuGet
 
                         if (!hasNativeLib)
                         {
-                            LogWarning($"The package `{packageIdentity}` doesn't support `{string.Join(",", _targetFrameworks.Select(x => x.Name))}`");
-                            continue;
+                            var dependencyGroups = downloadResult.PackageReader.NuspecReader.GetDependencyGroups(); // packageMeta.DependencySets can be empty
+                            resolvedDependencyGroups = NuGetHelper.GetCompatiblePackageDependencyGroups(dependencyGroups, _targetFrameworks).ToList();
+
+                            if (!resolvedDependencyGroups.Any())
+                            {
+                                LogWarning($"The package `{packageIdentity}` doesn't support `{string.Join(",", _targetFrameworks.Select(x => x.Name))}`");
+
+                                continue;
+                            }
                         }
                     }
 


### PR DESCRIPTION
Sometimes `dependencyGroups` property which is used used to detect target framework is empty.

For example, this occures for the following `.nuspec`:

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Name</id>
    <version>1.0.0.0</version>
    <authors>Me</authors>
    <description>Me</description>
    <repository type="git" commit="sha" />
    <dependencies>
      <group targetFramework=".NETStandard2.0" />
    </dependencies>
  </metadata>
</package>
```

when the package was hosted on gitlab package registry

<img src="https://github-production-user-asset-6210df.s3.amazonaws.com/22914850/265131146-e18a7223-d12a-40c8-904d-d57a368cfc4b.png" data-canonical-src="https://github-production-user-asset-6210df.s3.amazonaws.com/22914850/265131146-e18a7223-d12a-40c8-904d-d57a368cfc4b.png" width="500" />

Propably this is a gitlab issue, but I think to be on the safe side it's better to handle such cases