### PR TITLE
Fill in the displayName field in Unity's package.json file

### DIFF
--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -31,7 +31,7 @@ namespace UnityNuGet
     public class RegistryCache
     {
         public static readonly bool IsRunningOnAzure = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"));
-        
+
         // Change this version number if the content of the packages are changed by an update of this class
         private const string CurrentRegistryVersion = "1.6.0";
 
@@ -209,7 +209,7 @@ namespace UnityNuGet
                 // Clear the cache entirely
                 _npmPackageRegistry.Reset();
             }
-            
+
             var regexFilter = Filter != null ? new Regex(Filter, RegexOptions.IgnoreCase) : null;
             if (Filter != null)
             {
@@ -1073,6 +1073,7 @@ namespace UnityNuGet
             var unityPackage = new UnityPackage
             {
                 Name = npmPackageInfo.Name,
+                DisplayName = npmPackageVersion.DisplayName,
                 Version = npmPackageVersion.Version,
                 Description = npmPackageInfo.Description,
                 Unity = npmPackageVersion.Unity

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -33,7 +33,7 @@ namespace UnityNuGet
         public static readonly bool IsRunningOnAzure = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME"));
 
         // Change this version number if the content of the packages are changed by an update of this class
-        private const string CurrentRegistryVersion = "1.6.0";
+        private const string CurrentRegistryVersion = "1.7.0";
 
         private static readonly Encoding Utf8EncodingNoBom = new UTF8Encoding(false, false);
         private readonly string _rootPersistentFolder;

--- a/src/UnityNuGet/UnityPackage.cs
+++ b/src/UnityNuGet/UnityPackage.cs
@@ -17,6 +17,9 @@ namespace UnityNuGet
         [JsonProperty("name")]
         public string? Name { get; set; }
 
+        [JsonProperty("displayName")]
+        public string? DisplayName { get; set; }
+
         [JsonProperty("version")]
         public string? Version { get; set; }
 


### PR DESCRIPTION
If the package is embedded (Manually copied to /Packages), it will look like this:

![image](https://github.com/xoofx/UnityNuGet/assets/950602/de5fc231-7059-4508-bde5-f8c83a42f0e6)
