### PR TITLE
Add IdentityModel packages

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -706,6 +706,22 @@
     "listed": true,
     "version": "2.0.0"
   },
+  "Microsoft.IdentityModel.Abstractions": {
+    "listed": true,
+    "version": "6.18.0"
+  },
+  "Microsoft.IdentityModel.JsonWebTokens": {
+    "listed": true,
+    "version": "5.3.0"
+  },
+  "Microsoft.IdentityModel.Logging": {
+    "listed": true,
+    "version": "5.3.0"
+  },
+  "Microsoft.IdentityModel.Tokens": {
+    "listed": true,
+    "version": "5.3.0"
+  },
   "Microsoft.IO.RecyclableMemoryStream": {
     "listed": true,
     "version": "1.4.0"
@@ -845,6 +861,10 @@
   "Polly.Contrib.WaitAndRetry": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "Polly.Core": {
+    "listed": true,
+    "version": "8.0.0"
   },
   "Polly.Extensions.Http": {
     "listed": true,
@@ -1081,6 +1101,10 @@
   "System.Formats.Asn1": {
     "listed": true,
     "version": "5.0.0"
+  },
+  "System.IdentityModel.Tokens.Jwt": {
+    "listed": true,
+    "version": "5.3.0"
   },
   "System.Interactive.Async": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt/
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


