### PR TITLE
Add MQTTnet package

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -838,8 +838,7 @@
     "version": "0.1.0"
   },
   "NETStandard.Library": {
-    "listed": true,
-    "version": "2.0.0"
+    "ignore": true
   },
   "Newtonsoft.Json": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -829,6 +829,10 @@
     "listed": true,
     "version": "2.7.0"
   },
+  "MQTTnet": {
+    "listed": true,
+    "version": "3.0.15"
+  },
   "NeoSmart.Caching.Sqlite": {
     "listed": true,
     "version": "0.1.0"

--- a/registry.json
+++ b/registry.json
@@ -831,11 +831,14 @@
   },
   "MQTTnet": {
     "listed": true,
-    "version": "3.0.15"
+    "version": "2.5.1"
   },
   "NeoSmart.Caching.Sqlite": {
     "listed": true,
     "version": "0.1.0"
+  },
+  "NETStandard.Library": {
+    "ignore": true
   },
   "Newtonsoft.Json": {
     "listed": true,
@@ -1138,6 +1141,15 @@
     "listed": true,
     "version": "4.4.0"
   },
+  "System.Net.Security": {
+    "ignore": true
+  },
+  "System.Net.WebSockets": {
+    "ignore": true
+  },
+  "System.Net.WebsSockets.Client": {
+    "ignore": true
+  },
   "System.Numerics.Vectors": {
     "listed": false,
     "version": "4.4.0"
@@ -1233,6 +1245,9 @@
   "System.Threading.Tasks.Extensions": {
     "listed": false,
     "version": "4.4.0"
+  },
+  "System.Threading.Thread": {
+    "ignore": true
   },
   "Telnet": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -838,7 +838,8 @@
     "version": "0.1.0"
   },
   "NETStandard.Library": {
-    "ignore": true
+    "listed": true,
+    "version": "2.0.0"
   },
   "Newtonsoft.Json": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1141,12 +1141,6 @@
     "listed": true,
     "version": "4.4.0"
   },
-  "System.Net.Security": {
-    "ignore": true
-  },
-  "System.Net.WebSockets": {
-    "ignore": true
-  },
   "System.Net.WebsSockets.Client": {
     "ignore": true
   },
@@ -1245,9 +1239,6 @@
   "System.Threading.Tasks.Extensions": {
     "listed": false,
     "version": "4.4.0"
-  },
-  "System.Threading.Thread": {
-    "ignore": true
   },
   "Telnet": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/MQTTnet/
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

The version is not the first version available on .NETStandard2.0, that would be 2.5.1.
There are additional dependencies listed for versions before 3.0.15:
NETStandard.Library (>= 2.0.0)
System.Net.Security (>= 4.3.2)
System.Net.WebSockets (>= 4.3.0)
System.Net.WebSockets.Client (>= 4.3.1)
System.Threading.Thread (>= 4.3.0)
These look like they are part of the .NETStandard2.0 itself?

Not sure if I should add those with "ignore": true or if having not-lowest-version is ok.