### PR TITLE
Add HtmlAgilityPack

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -358,6 +358,10 @@
       "UNITY_EDITOR"
     ]
   },
+  "HtmlAgilityPack": {
+    "listed": true,
+    "version": "1.5.3"
+  },
   "IDisposableAnalyzers": {
     "listed": true,
     "version": "1.0.0",

--- a/registry.json
+++ b/registry.json
@@ -360,7 +360,7 @@
   },
   "HtmlAgilityPack": {
     "listed": true,
-    "version": "1.5.3"
+    "version": "1.11.24"
   },
   "IDisposableAnalyzers": {
     "listed": true,
@@ -1233,10 +1233,6 @@
   "System.Threading.Tasks.Extensions": {
     "listed": false,
     "version": "4.4.0"
-  },
-  "System.Xml.XPath.XmlDocument": {
-    "listed": true,
-    "version": "4.3.0"
   },
   "Telnet": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1234,6 +1234,10 @@
     "listed": false,
     "version": "4.4.0"
   },
+  "System.Xml.XPath.XmlDocument": {
+    "listed": true,
+    "version": "4.3.0"
+  },
   "Telnet": {
     "listed": true,
     "version": "0.8.6"

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -120,6 +120,8 @@ namespace UnityNuGet.Tests
                 @"StrongInject.Extensions.DependencyInjection",
                 // Versions < 4.6.0 in theory supports .netstandard2.0 but it doesn't have a lib folder with assemblies and it makes it fail.
                 @"System.Private.ServiceModel",
+                // Does not target .netstandard2.0 specifically
+                @"System.Xml.XPath.XmlDocument",
                 // Versions < 0.8.6 depend on LiteGuard, a deprecated dependency.
                 @"Telnet"
             };

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -110,6 +110,8 @@ namespace UnityNuGet.Tests
                 @"AWSSDK.S3",
                 // All versions target "Any" and not .netstandard2.0 / 2.1
                 @"AWSSDK.SecurityToken",
+                // Versions prior to 1.11.24 depend on System.Xml.XPath.XmlDocument which does not target .netstandard2.0
+                @"HtmlAgilityPack",
                 // Although 2.x targets .netstandard2.0 it has an abandoned dependency (Remotion.Linq) that does not target .netstandard2.0.
                 // 3.1.0 is set because 3.0.x only targets .netstandard2.1.
                 @"Microsoft.EntityFrameworkCore.*",
@@ -120,8 +122,6 @@ namespace UnityNuGet.Tests
                 @"StrongInject.Extensions.DependencyInjection",
                 // Versions < 4.6.0 in theory supports .netstandard2.0 but it doesn't have a lib folder with assemblies and it makes it fail.
                 @"System.Private.ServiceModel",
-                // Does not target .netstandard2.0 specifically
-                @"System.Xml.XPath.XmlDocument",
                 // Versions < 0.8.6 depend on LiteGuard, a deprecated dependency.
                 @"Telnet"
             };


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/HtmlAgilityPack
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


