### PR TITLE
Add AWSSDK.CognitoIdentity and AWSSDK.CognitoIdentityProvider

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -35,6 +35,14 @@
     "listed": true,
     "version": "1.1.4.3"
   },
+  "AWSSDK.CognitoIdentity": {
+    "listed": true,
+    "version": "3.3.100"
+  },
+  "AWSSDK.CognitoIdentityProvider": {
+    "listed": true,
+    "version": "3.3.100"
+  },
   "AWSSDK.Core": {
     "listed": true,
     "version": "3.3.100"

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -107,6 +107,10 @@ namespace UnityNuGet.Tests
 
             var excludedPackages = new string[] {
                 // All versions target "Any" and not .netstandard2.0 / 2.1
+                @"AWSSDK.CognitoIdentity",
+                // All versions target "Any" and not .netstandard2.0 / 2.1
+                @"AWSSDK.CognitoIdentityProvider",
+                // All versions target "Any" and not .netstandard2.0 / 2.1
                 @"AWSSDK.S3",
                 // All versions target "Any" and not .netstandard2.0 / 2.1
                 @"AWSSDK.SecurityToken",

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -108,11 +108,8 @@ namespace UnityNuGet.Tests
             var excludedPackages = new string[] {
                 // All versions target "Any" and not .netstandard2.0 / 2.1
                 @"AWSSDK.CognitoIdentity",
-                // All versions target "Any" and not .netstandard2.0 / 2.1
                 @"AWSSDK.CognitoIdentityProvider",
-                // All versions target "Any" and not .netstandard2.0 / 2.1
                 @"AWSSDK.S3",
-                // All versions target "Any" and not .netstandard2.0 / 2.1
                 @"AWSSDK.SecurityToken",
                 // Although 2.x targets .netstandard2.0 it has an abandoned dependency (Remotion.Linq) that does not target .netstandard2.0.
                 // 3.1.0 is set because 3.0.x only targets .netstandard2.1.


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/AWSSDK.CognitoIdentity
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/AWSSDK.CognitoIdentityProvider
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


