### PR TITLE
Ensure the dependencies' versions match the registry

### DIFF
--- a/src/UnityNuGet/UnityNuGet.csproj
+++ b/src/UnityNuGet/UnityNuGet.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.7.1" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.7.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="NUglify" Version="1.21.0" />
     <PackageReference Include="Scriban" Version="5.9.0" />

--- a/src/UnityNuGet/UnityNuGet.csproj
+++ b/src/UnityNuGet/UnityNuGet.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Include="NuGet.PackageManagement" Version="6.7.0" />
+    <PackageReference Include="NuGet.PackageManagement" Version="6.7.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="NUglify" Version="1.21.0" />
     <PackageReference Include="Scriban" Version="5.9.0" />


### PR DESCRIPTION
UnityNuget has a code path that is trying to rewrite package dependencies such that their versions correspond to the ones in `registry.json`. For instance, consider the case of a package dependency `A [1.1.1, )` and a registry entry for that package `A [8.0.0]`. The code will try to change the dependency to reference `A: 8.0.0`, as that is what it finds in the `registry.json`.

However, this version resolution, from 1.1.1 to 8.0.0 is broken. What currently happens is: the code looks-up all available packages A in the feed and stop at the first version that was compatible with the dependency (and not the registry). So if the feed has newer packages, say `A 9.0.0`, UnityNuget would find that first and rewrite the dependency as `A: 9.0.0`, regardless of whether 9.0.0 was actually compatible with its own `registry.json`

Fixes #281 