### PR TITLE
Added System.Threading.Tasks.Dataflow@6.0.0

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1286,7 +1286,7 @@
   },
   "System.Threading.Tasks.Dataflow": {
     "listed": true,
-    "version": "6.0.0"
+    "version": "4.8.0"
   },
   "System.Threading.Tasks.Extensions": {
     "listed": false,

--- a/registry.json
+++ b/registry.json
@@ -1284,6 +1284,10 @@
     "listed": true,
     "version": "7.0.0"
   },
+  "System.Threading.Tasks.Dataflow": {
+    "listed": true,
+    "version": "6.0.0"
+  },
   "System.Threading.Tasks.Extensions": {
     "listed": false,
     "version": "4.4.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/System.Threading.Tasks.Dataflow
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

- Lowest version on nuget.org is 6.0.0. 
- Package is tested and used in EtAlii.UniCon (available on OpenUPM)
- Package has no dependencies.

Sidenote: Great initiative - I finally have some time to create PR's for some of the packages we are still using as embedded assemblies. 
