### PR TITLE
Added Serilog.Enrichers.Memory@1.0.4

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1010,6 +1010,10 @@
     "listed": true,
     "version": "0.9.0"
   },
+  "Serilog.Enrichers.Memory": {
+    "listed": true,
+    "version": "1.0.4"
+  },
   "Serilog.Extensions.Hosting": {
     "listed": true,
     "version": "2.0.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package: https://www.nuget.org/packages/Serilog.Enrichers.Memory
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

- Lowest version on nuget.org with .NET standard 2.0 assemblies is 1.0.4. 
- Package is tested and used in EtAlii.UniCon (available on OpenUPM)
- Package has no dependencies.

