### PR TITLE
Added Serilog.Expressions@1.0.0

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1112,7 +1112,7 @@
   },
   "Serilog.Expressions": {
     "listed": true,
-    "version": "1.1.0"
+    "version": "3.2.1"
   },
   "Serilog.Extensions.Hosting": {
     "listed": true,
@@ -1235,10 +1235,6 @@
   "SunCalcNet": {
     "listed": true,
     "version": "1.1.0"
-  },
-  "Superpower": {
-    "listed": true,
-    "version": "2.2.0"
   },
   "System.Buffers": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1236,6 +1236,10 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "Superpower": {
+    "listed": true,
+    "version": "2.2.0"
+  },
   "System.Buffers": {
     "listed": true,
     "version": "4.4.0"

--- a/registry.json
+++ b/registry.json
@@ -1010,6 +1010,10 @@
     "listed": true,
     "version": "0.9.0"
   },
+  "Serilog.Expressions": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "Serilog.Extensions.Hosting": {
     "listed": true,
     "version": "2.0.0"

--- a/registry.json
+++ b/registry.json
@@ -1012,7 +1012,7 @@
   },
   "Serilog.Expressions": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "Serilog.Extensions.Hosting": {
     "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -120,8 +120,10 @@ namespace UnityNuGet.Tests
                 // Monomod Versions < 18.11.9.9 depend on System.Runtime.Loader which doesn't ship .netstandard2.0.
                 @"MonoMod.Utils",
                 @"MonoMod.RuntimeDetour",
-                // MumbleSharp < 2.0.0 depend on NAudio which doesn't ship .netstandard2.0.
+                // Versions < 2.0.0 depend on NAudio which doesn't ship .netstandard2.0.
                 @"MumbleSharp",
+                // Versions < 3.2.1 depend on Nullable which doesn't ship .netstandard2.0.
+                @"Serilog.Expressions",
                 // Versions < 1.4.1 has dependencies on Microsoft.AspNetCore.*.
                 @"StrongInject.Extensions.DependencyInjection",
                 // Versions < 4.6.0 in theory supports .netstandard2.0 but it doesn't have a lib folder with assemblies and it makes it fail.


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package: https://www.nuget.org/packages/Serilog.Expressions
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

- Lowest version on nuget.org with .NET standard 2.0 assemblies is 1.0.0.
- Package is tested and used in EtAlii.UniCon (available on OpenUPM)
- Package has no dependencies.
