### PR TITLE
Add Akka.Cluster.Hosting and it's dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -3,6 +3,58 @@
     "listed": true,
     "version": "1.4.1"
   },
+  "Akka.Cluster": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Cluster.Hosting": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "Akka.Cluster.Sharding": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Cluster.Tools": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Coordination": {
+    "listed": true,
+    "version": "1.4.4"
+  },
+  "Akka.DependencyInjection": {
+    "listed": true,
+    "version": "1.4.15"
+  },
+  "Akka.DistributedData": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.DistributedData.LightningDB": {
+    "listed": true,
+    "version": "1.4.7"
+  },
+  "Akka.Hosting": {
+    "listed": true,
+    "version": "0.1.0"
+  },
+  "Akka.Persistence": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Persistence.Hosting": {
+    "listed": true,
+    "version": "0.3.3"
+  },
+  "Akka.Remote": {
+    "listed": true,
+    "version": "1.4.1"
+  },
+  "Akka.Remote.Hosting": {
+    "listed": true,
+    "version": "0.1.0"
+  },
   "Antlr4.Runtime.Standard": {
     "listed": true,
     "version": "4.9.1"
@@ -267,6 +319,26 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "DotNetty.Buffers": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Codecs": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Common": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Handlers": {
+    "listed": true,
+    "version": "0.7.0"
+  },
+  "DotNetty.Transport": {
+    "listed": true,
+    "version": "0.7.0"
+  },
   "Eflatun.Expansions": {
     "listed": true,
     "version": "0.0.1"
@@ -380,6 +452,10 @@
     "listed": true,
     "version": "1.11.24"
   },
+  "Hyperion": {
+    "listed": true,
+    "version": "0.9.9"
+  },
   "IdentityModel": {
     "listed": true,
     "version": "2.13.0"
@@ -408,6 +484,14 @@
   "Kdl.NetStandard.x64": {
     "listed": true,
     "version": "2.0.0"
+  },
+  "LightningDB": {
+    "listed": true,
+    "version": "0.11.0"
+  },
+  "LightningDB.Vendored.Akka": {
+    "listed": true,
+    "version": "0.14.0"
   },
   "LiteDB": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Akka.Cluster.Hosting
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


