### PR TITLE
Add MumbleSharp

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -871,6 +871,18 @@
     "listed": true,
     "version": "2.7.0"
   },
+  "MumbleSharp": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "NAudio.Core": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "NAudio.WinMM": {
+    "listed": true,
+    "version": "2.0.0"
+  },
   "NeoSmart.Caching.Sqlite": {
     "listed": true,
     "version": "0.1.0"

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -120,6 +120,8 @@ namespace UnityNuGet.Tests
                 // Monomod Versions < 18.11.9.9 depend on System.Runtime.Loader which doesn't ship .netstandard2.0.
                 @"MonoMod.Utils",
                 @"MonoMod.RuntimeDetour",
+                // MumbleSharp < 2.0.0 depend on NAudio which doesn't ship .netstandard2.0.
+                @"MumbleSharp",
                 // Versions < 1.4.1 has dependencies on Microsoft.AspNetCore.*.
                 @"StrongInject.Extensions.DependencyInjection",
                 // Versions < 4.6.0 in theory supports .netstandard2.0 but it doesn't have a lib folder with assemblies and it makes it fail.


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/MumbleSharp
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


