### PR TITLE
Add Akka.Analyzers and it's dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -3,6 +3,11 @@
     "listed": true,
     "version": "1.4.1"
   },
+  "Akka.Analyzers": {
+    "listed": true,
+    "version": "0.1.0",
+    "analyzer": true
+  },
   "Akka.Cluster": {
     "listed": true,
     "version": "1.4.1"
@@ -456,6 +461,10 @@
     "listed": true,
     "version": "1.11.24"
   },
+  "Humanizer.Core": {
+    "listed": true,
+    "version": "2.3.2"
+  },
   "Hyperion": {
     "listed": true,
     "version": "0.9.9"
@@ -590,6 +599,11 @@
     "listed": true,
     "version": "8.0.0"
   },
+  "Microsoft.CodeAnalysis": {
+    "listed": true,
+    "version": "3.0.0",
+    "analyzer": true
+  },
   "Microsoft.CodeAnalysis.Analyzers": {
     "listed": true,
     "version": "3.0.0",
@@ -614,6 +628,10 @@
       "UNITY_EDITOR"
     ]
   },
+  "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+    "listed": true,
+    "version": "3.0.0"
+  },
   "Microsoft.CodeAnalysis.NetAnalyzers": {
     "listed": true,
     "version": "5.0.3",
@@ -623,6 +641,18 @@
     "listed": true,
     "version": "2.9.0",
     "analyzer": true
+  },
+  "Microsoft.CodeAnalysis.VisualBasic": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+    "listed": true,
+    "version": "3.0.0"
+  },
+  "Microsoft.CodeAnalysis.Workspaces.Common": {
+    "listed": true,
+    "version": "3.0.0"
   },
   "Microsoft.CSharp": {
     "ignore": true
@@ -1259,6 +1289,30 @@
   "System.ComponentModel.Annotations": {
     "listed": true,
     "version": "4.4.0"
+  },
+  "System.Composition": {
+    "listed": true,
+    "version": "6.0.0"
+  },
+  "System.Composition.AttributedModel": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "System.Composition.Convention": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "System.Composition.Hosting": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "System.Composition.Runtime": {
+    "listed": true,
+    "version": "1.1.0"
+  },
+  "System.Composition.TypedParts": {
+    "listed": true,
+    "version": "1.1.0"
   },
   "System.Configuration.ConfigurationManager": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Akka.Analyzers
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [ ] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [ ] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

No .NETStandard2.0 assemblies as this is an analyzer.
No standalone player support as this is an analyzer.