### PR TITLE
ReactiveProperty-5.0.0, System.Reactive-4.0.0

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1057,6 +1057,14 @@
     "listed": true,
     "version": "0.0.3"
   },
+  "ReactiveProperty": {
+    "listed": true,
+    "version": "5.0.0"
+  },
+  "ReactiveProperty.Core": {
+    "listed": true,
+    "version": "7.0.0"
+  },
   "RestSharp": {
     "listed": true,
     "version": "106.0.0"
@@ -1332,14 +1340,6 @@
   "System.Reactive": {
     "listed": true,
     "version": "4.0.0"
-  },
-  "ReactiveProperty": {
-    "listed": true,
-    "version": "5.0.0"
-  },
-  "ReactiveProperty.Core": {
-    "listed": true,
-    "version": "7.0.0"
   },
   "System.Reflection.DispatchProxy": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1333,6 +1333,14 @@
     "listed": true,
     "version": "4.0.0"
   },
+  "ReactiveProperty": {
+    "listed": true,
+    "version": "5.0.0"
+  },
+  "ReactiveProperty.Core": {
+    "listed": true,
+    "version": "7.0.0"
+  },
   "System.Reflection.DispatchProxy": {
     "listed": true,
     "version": "4.4.0"

--- a/registry.json
+++ b/registry.json
@@ -1329,6 +1329,10 @@
     "listed": false,
     "version": "4.6.0"
   },
+  "System.Reactive": {
+    "listed": true,
+    "version": "4.0.0"
+  },
   "System.Reflection.DispatchProxy": {
     "listed": true,
     "version": "4.4.0"
@@ -1356,6 +1360,11 @@
   "System.Runtime.CompilerServices.Unsafe": {
     "listed": true,
     "version": "4.4.0"
+  },
+  "System.Runtime.InteropServices.WindowsRuntime": {
+    "listed": false,
+    "version": "4.3.0",
+    "ignore": true
   },
   "System.Security.AccessControl": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/ReactiveProperty
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


