### PR TITLE
Dapplo.Windows.User32-1.0.26, Dapplo.Windows.Input-1.0.26

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -326,19 +326,19 @@
   },
   "Dapplo.Windows.Common": {
     "listed": true,
-    "version": "[1.0.26]"
+    "version": "1.0.26"
   },
   "Dapplo.Windows.Input": {
     "listed": true,
-    "version": "[1.0.26]"
+    "version": "1.0.26"
   },
   "Dapplo.Windows.Messages": {
     "listed": true,
-    "version": "[1.0.26]"
+    "version": "1.0.26"
   },
   "Dapplo.Windows.User32": {
     "listed": true,
-    "version": "[1.0.26]"
+    "version": "1.0.26"
   },
   "Dev.ComradeVanti.Nothing": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -328,6 +328,10 @@
     "listed": true,
     "version": "1.0.26"
   },
+  "Dapplo.Windows.Input": {
+    "listed": true,
+    "version": "1.0.26"
+  },
   "Dev.ComradeVanti.Nothing": {
     "listed": true,
     "version": "1.0.0"

--- a/registry.json
+++ b/registry.json
@@ -332,6 +332,10 @@
     "listed": true,
     "version": "1.0.26"
   },
+  "Dapplo.Windows.Messages": {
+    "listed": true,
+    "version": "1.0.26"
+  },
   "Dev.ComradeVanti.Nothing": {
     "listed": true,
     "version": "1.0.0"

--- a/registry.json
+++ b/registry.json
@@ -1395,6 +1395,11 @@
     "listed": true,
     "version": "4.4.0"
   },
+  "System.Runtime.InteropServices.WindowsRuntime": {
+    "listed": false,
+    "version": "4.3.0",
+    "ignore": true
+  },
   "System.Security.AccessControl": {
     "listed": true,
     "version": "4.4.0"

--- a/registry.json
+++ b/registry.json
@@ -320,6 +320,10 @@
     "listed": true,
     "version": "3.0.0"
   },
+  "Dapplo.Log": {
+    "listed": true,
+    "version": "1.4.1"
+  },
   "Dev.ComradeVanti.Nothing": {
     "listed": true,
     "version": "1.0.0"

--- a/registry.json
+++ b/registry.json
@@ -322,7 +322,7 @@
   },
   "Dapplo.Log": {
     "listed": true,
-    "version": "1.4.1"
+    "version": "1.3.17"
   },
   "Dapplo.Windows.Common": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -326,19 +326,19 @@
   },
   "Dapplo.Windows.Common": {
     "listed": true,
-    "version": "1.0.26"
+    "version": "[1.0.26]"
   },
   "Dapplo.Windows.Input": {
     "listed": true,
-    "version": "1.0.26"
+    "version": "[1.0.26]"
   },
   "Dapplo.Windows.Messages": {
     "listed": true,
-    "version": "1.0.26"
+    "version": "[1.0.26]"
   },
   "Dapplo.Windows.User32": {
     "listed": true,
-    "version": "1.0.26"
+    "version": "[1.0.26]"
   },
   "Dev.ComradeVanti.Nothing": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -324,6 +324,10 @@
     "listed": true,
     "version": "1.4.1"
   },
+  "Dapplo.Windows.Common": {
+    "listed": true,
+    "version": "1.0.26"
+  },
   "Dev.ComradeVanti.Nothing": {
     "listed": true,
     "version": "1.0.0"

--- a/registry.json
+++ b/registry.json
@@ -336,6 +336,10 @@
     "listed": true,
     "version": "1.0.26"
   },
+  "Dapplo.Windows.User32": {
+    "listed": true,
+    "version": "1.0.26"
+  },
   "Dev.ComradeVanti.Nothing": {
     "listed": true,
     "version": "1.0.0"

--- a/registry.json
+++ b/registry.json
@@ -1343,6 +1343,10 @@
     "listed": false,
     "version": "4.6.0"
   },
+  "System.Reactive": {
+    "listed": true,
+    "version": "4.0.0"
+  },
   "System.Reflection.DispatchProxy": {
     "listed": true,
     "version": "4.4.0"

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -129,7 +129,12 @@ namespace UnityNuGet.Tests
                 // Versions < 4.6.0 in theory supports .netstandard2.0 but it doesn't have a lib folder with assemblies and it makes it fail.
                 @"System.Private.ServiceModel",
                 // Versions < 0.8.6 depend on LiteGuard, a deprecated dependency.
-                @"Telnet"
+                @"Telnet",
+                // Version < 1.0.26 depends on Microsoft.Windows.Compatibility, this one has tons of dependencies that don't target .netstandard2.0. And one of them is System.Speech that doesn't work in Unity.
+                @"Dapplo.Windows.Common",
+                @"Dapplo.Windows.Input",
+                @"Dapplo.Windows.Messages",
+                @"Dapplo.Windows.User32"
             };
 
             var excludedPackagesRegex = new Regex(@$"^{string.Join('|', excludedPackages)}$");


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Dapplo.Windows.User32
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


