### PR TITLE
Lift packages with too many versions

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -98,15 +98,15 @@
   },
   "AWSSDK.Core": {
     "listed": true,
-    "version": "3.3.100"
+    "version": "3.7.302.8"
   },
   "AWSSDK.S3": {
     "listed": true,
-    "version": "3.3.100"
+    "version": "3.7.302.8"
   },
   "AWSSDK.SecurityToken": {
     "listed": true,
-    "version": "3.3.100"
+    "version": "3.7.302.8"
   },
   "Ben.Demystifier": {
     "listed": true,
@@ -314,7 +314,7 @@
   },
   "CSharpFunctionalExtensions": {
     "listed": true,
-    "version": "1.8.1"
+    "version": "2.40.3"
   },
   "CsvHelper": {
     "listed": true,
@@ -405,7 +405,7 @@
   },
   "Google.Apis.AndroidPublisher.v3": {
     "listed": true,
-    "version": "1.35.1.1312"
+    "version": "1.66.0.3324"
   },
   "Google.Apis.Auth": {
     "listed": true,
@@ -1475,15 +1475,15 @@
   },
   "UnitsNet": {
     "listed": true,
-    "version": "4.0.0"
+    "version": "5.28.0"
   },
   "UnitsNet.NumberExtensions": {
     "listed": true,
-    "version": "4.44.0"
+    "version": "5.28.0"
   },
   "UnitsNet.Serialization.JsonNet": {
     "listed": true,
-    "version": "4.0.0"
+    "version": "5.28.0"
   },
   "Validation": {
     "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -109,9 +109,12 @@ namespace UnityNuGet.Tests
 
             var excludedPackages = new string[] {
                 // All versions target "Any" and not .netstandard2.0 / 2.1
-                @"AWSSDK.S3",
-                // All versions target "Any" and not .netstandard2.0 / 2.1
-                @"AWSSDK.SecurityToken",
+                // It has too many versions, the minimum version is lifted so as not to process so many versions
+                @"AWSSDK.*",
+                // It has too many versions, the minimum version is lifted so as not to process so many versions
+                @"CSharpFunctionalExtensions",
+                // It has too many versions, the minimum version is lifted so as not to process so many versions
+                @"Google.Apis.AndroidPublisher.v3",
                 // Versions prior to 1.11.24 depend on System.Xml.XPath.XmlDocument which does not target .netstandard2.0
                 @"HtmlAgilityPack",
                 // Although 2.x targets .netstandard2.0 it has an abandoned dependency (Remotion.Linq) that does not target .netstandard2.0.
@@ -129,7 +132,9 @@ namespace UnityNuGet.Tests
                 // Versions < 4.6.0 in theory supports .netstandard2.0 but it doesn't have a lib folder with assemblies and it makes it fail.
                 @"System.Private.ServiceModel",
                 // Versions < 0.8.6 depend on LiteGuard, a deprecated dependency.
-                @"Telnet"
+                @"Telnet",
+                // It has too many versions, the minimum version is lifted so as not to process so many versions
+                @"UnitsNet.*"
             };
 
             var excludedPackagesRegex = new Regex(@$"^{string.Join('|', excludedPackages)}$");


### PR DESCRIPTION
I've lifted the version of non-Microsoft packages that are over 100 versions to reduce deployment time and disk space.

Anyone relying on an older version of these packages will have to update those dependencies or host UnityNuGet on their own.

Affects:

AWSSDK.*
CSharpFunctionalExtensions
Google.Apis.AndroidPublisher.v3
UnitsNet.*
