### PR TITLE
Add ObservableCollections and ObservableCollections.R3

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -157,7 +157,7 @@
   },
   "CLSS.ExtensionMethods.IComparable.ClampToRange": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.3.0"
   },
   "CLSS.ExtensionMethods.IComparable.InRange": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -257,7 +257,7 @@
   },
   "CLSS.Types.AgnosticObjectPool": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "CLSS.Types.EventLatch": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -137,7 +137,7 @@
   },
   "CLSS.Constants.CollectionPool": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "CLSS.Constants.DefaultRandom": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1029,6 +1029,14 @@
     "version": "[2.0.0,3.3.0]",
     "analyzer": true
   },
+  "ObservableCollections": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "ObservableCollections.R3": {
+    "listed": true,
+    "version": "2.0.0"
+  },
   "OneOf": {
     "listed": true,
     "version": "3.0.205"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/ObservableCollections
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/ObservableCollections.R3
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


