### PR TITLE
Earlier versions of some CLSS packages have been removed from nuget.org

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -137,7 +137,7 @@
   },
   "CLSS.Constants.CollectionPool": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "CLSS.Constants.DefaultRandom": {
     "listed": true,
@@ -157,7 +157,7 @@
   },
   "CLSS.ExtensionMethods.IComparable.ClampToRange": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.3.0"
   },
   "CLSS.ExtensionMethods.IComparable.InRange": {
     "listed": true,
@@ -257,7 +257,7 @@
   },
   "CLSS.Types.AgnosticObjectPool": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "CLSS.Types.EventLatch": {
     "listed": true,


### PR DESCRIPTION
Tests are failing due to apparent removal of earlier package versions from nuget.org.
Bumped minimum versions to match what is currently available.