### PR TITLE
Add Elastic/Open Search Sinks

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1249,6 +1249,10 @@
     "listed": true,
     "version": "1.0.0"
   },
+  "Serilog.Sinks.PeriodicBatching": {
+    "listed": true,
+    "version": "2.2.0"
+  },
   "Serilog.Sinks.Trace": {
     "listed": true,
     "version": "3.0.0"

--- a/registry.json
+++ b/registry.json
@@ -372,6 +372,10 @@
     "listed": true,
     "version": "0.0.1"
   },
+  "Elasticsearch.Net": {
+    "listed": true,
+    "version": "6.3.0"
+  },
   "ErrorProne.NET.CoreAnalyzers": {
     "listed": true,
     "version": "0.1.2",
@@ -1045,6 +1049,10 @@
     "listed": true,
     "version": "3.0.205"
   },
+  "OpenSearch.Net": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "Polly": {
     "listed": true,
     "version": "6.0.1"
@@ -1201,6 +1209,14 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "Serilog.Formatting.Elasticsearch": {
+    "listed": true,
+    "version": "8.0.0"
+  },
+  "Serilog.Formatting.OpenSearch": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "Serilog.Settings.Configuration": {
     "listed": true,
     "version": "3.0.0"
@@ -1217,6 +1233,10 @@
     "listed": true,
     "version": "1.0.1"
   },
+  "Serilog.Sinks.Elasticsearch": {
+    "listed": true,
+    "version": "8.0.0"
+  },
   "Serilog.Sinks.File": {
     "listed": true,
     "version": "4.1.0"
@@ -1224,6 +1244,10 @@
   "Serilog.Sinks.Graylog": {
     "listed": true,
     "version": "1.1.89"
+  },
+  "Serilog.Sinks.OpenSearch": {
+    "listed": true,
+    "version": "1.0.0"
   },
   "Serilog.Sinks.Trace": {
     "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -112,6 +112,8 @@ namespace UnityNuGet.Tests
                 @"AWSSDK.*",
                 // It has too many versions, the minimum version is lifted so as not to process so many versions
                 @"CSharpFunctionalExtensions",
+                // Some versions between 5.6.4 and 6.3.0 doesn't ship .netstandard2.0.
+                @"Elasticsearch.Net",
                 // It has too many versions, the minimum version is lifted so as not to process so many versions
                 @"Google.Apis.AndroidPublisher.v3",
                 // Versions prior to 1.11.24 depend on System.Xml.XPath.XmlDocument which does not target .netstandard2.0


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Serilog.Sinks.OpenSearch
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


