### PR TITLE
Add ClosedXML and its dependencies

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -135,6 +135,10 @@
     "listed": true,
     "version": "1.0.2"
   },
+  "ClosedXML": {
+    "listed": true,
+    "version": "0.92.1"
+  },
   "CLSS.Constants.CollectionPool": {
     "listed": true,
     "version": "1.1.0"
@@ -348,6 +352,14 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "DocumentFormat.OpenXml": {
+    "listed": true,
+    "version": "2.10.0"
+  },
+  "DocumentFormat.OpenXml.Framework": {
+    "listed": true,
+    "version": "3.0.0"
+  },
   "DotNetty.Buffers": {
     "listed": true,
     "version": "0.7.0"
@@ -403,6 +415,14 @@
   "FastEnum": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "FastMember": {
+	"listed": true,
+	"version": "1.4.0"
+  },
+  "FastMember.Signed": {
+    "listed": true,
+    "version": "1.4.0"
   },
   "FluentAssertions": {
     "listed": true,
@@ -505,6 +525,10 @@
   "Injecter": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "Irony": {
+    "listed": true,
+    "version": "1.5.0"
   },
   "Jdenticon-net": {
     "listed": true,
@@ -1367,6 +1391,10 @@
     "listed": true,
     "version": "4.5.0"
   },
+  "System.Drawing.Common": {
+    "listed": true,
+    "version": "4.5.0"
+  },
   "System.Formats.Asn1": {
     "listed": true,
     "version": "5.0.0"
@@ -1386,6 +1414,10 @@
   "System.IO.FileSystem.AccessControl": {
     "listed": true,
     "version": "4.4.0"
+  },
+  "System.IO.Packaging": {
+    "listed": true,
+    "version": "6.0.0"
   },
   "System.IO.Pipelines": {
     "listed": true,
@@ -1572,6 +1604,10 @@
   "Websocketsharp.core": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "XLParser": {
+    "listed": true,
+    "version": "1.7.0"
   },
   "YamlDotNet": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -418,11 +418,11 @@
   },
   "FastMember": {
 	"listed": true,
-	"version": "1.4.0"
+	"version": "1.2.0"
   },
   "FastMember.Signed": {
     "listed": true,
-    "version": "1.4.0"
+    "version": "1.2.0"
   },
   "FluentAssertions": {
     "listed": true,
@@ -1189,6 +1189,9 @@
     "version": "4.10.0",
     "analyzer": true
   },
+  "runtime.native.System.Data.SqlClient.sni": {
+	"ignore": true
+  },
   "Scriban": {
     "listed": true,
     "version": "1.2.4"
@@ -1295,7 +1298,7 @@
   },
   "SixLabors.Fonts": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "[1.0.0,2.0.0)"
   },
   "SixLabors.ImageSharp": {
     "listed": true,
@@ -1383,6 +1386,10 @@
     "listed": true,
     "version": "4.4.0"
   },
+  "System.Data.SqlClient": {
+	"listed": true,
+	"version": "4.4.0"
+  },
   "System.Diagnostics.DiagnosticSource": {
     "listed": true,
     "version": "4.5.0"
@@ -1417,7 +1424,7 @@
   },
   "System.IO.Packaging": {
     "listed": true,
-    "version": "6.0.0"
+    "version": "4.5.0"
   },
   "System.IO.Pipelines": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -417,8 +417,8 @@
     "version": "1.0.0"
   },
   "FastMember": {
-	"listed": true,
-	"version": "1.2.0"
+    "listed": true,
+    "version": "1.2.0"
   },
   "FastMember.Signed": {
     "listed": true,
@@ -1190,7 +1190,7 @@
     "analyzer": true
   },
   "runtime.native.System.Data.SqlClient.sni": {
-	"ignore": true
+    "ignore": true
   },
   "Scriban": {
     "listed": true,
@@ -1387,8 +1387,8 @@
     "version": "4.4.0"
   },
   "System.Data.SqlClient": {
-	"listed": true,
-	"version": "4.4.0"
+    "listed": true,
+    "version": "4.4.0"
   },
   "System.Diagnostics.DiagnosticSource": {
     "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -140,7 +140,9 @@ namespace UnityNuGet.Tests
                 @"Dapplo.Windows.Messages",
                 @"Dapplo.Windows.User32",
                 // It has too many versions, the minimum version is lifted so as not to process so many versions
-                @"UnitsNet.*"
+                @"UnitsNet.*",
+                // Most versions < 1.7.0 don't target .netstandard2.0
+                @"XLParser"
             };
 
             var excludedPackagesRegex = new Regex(@$"^{string.Join('|', excludedPackages)}$");


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/ClosedXML/
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


