### PR TITLE
add zlogger and zstring

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1596,6 +1596,10 @@
     "listed": true,
     "version": "5.28.0"
   },
+  "Utf8StringInterpolation": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "Validation": {
     "listed": true,
     "version": "2.5.42"
@@ -1632,8 +1636,16 @@
     "listed": true,
     "version": "12.0.0"
   },
+  "ZLogger": {
+    "listed": true,
+    "version": "0.1.2"
+  },
   "ZstdSharp.Port": {
     "listed": true,
     "version": "0.5.0"
+  },
+  "ZString": {
+    "listed": true,
+    "version": "0.1.0"
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -1430,6 +1430,10 @@
     "listed": true,
     "version": "4.4.0"
   },
+  "System.IO.Hashing": {
+    "listed": false,
+    "version": "6.0.0"
+  },
   "System.IO.Packaging": {
     "listed": true,
     "version": "4.5.0"
@@ -1598,7 +1602,7 @@
   },
   "Utf8StringInterpolation": {
     "listed": true,
-    "version": "1.0.0"
+    "version": "1.2.0"
   },
   "Validation": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1602,7 +1602,7 @@
   },
   "Utf8StringInterpolation": {
     "listed": true,
-    "version": "1.2.0"
+    "version": "1.3.1"
   },
   "Validation": {
     "listed": true,
@@ -1642,7 +1642,7 @@
   },
   "ZLogger": {
     "listed": true,
-    "version": "0.1.2"
+    "version": "2.0.1"
   },
   "ZstdSharp.Port": {
     "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -144,7 +144,7 @@ namespace UnityNuGet.Tests
                 // Most versions < 1.7.0 don't target .netstandard2.0
                 @"XLParser",
                 // Versions < 1.3.1 has dependencies on PolySharp
-                @"Utf8StringInterpolation"
+                @"Utf8StringInterpolation",
                 // Versions 2.0.0 has dependencies on Utf8StringInterpolation 1.3.0
                 @"ZLogger"
             };

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -142,7 +142,11 @@ namespace UnityNuGet.Tests
                 // It has too many versions, the minimum version is lifted so as not to process so many versions
                 @"UnitsNet.*",
                 // Most versions < 1.7.0 don't target .netstandard2.0
-                @"XLParser"
+                @"XLParser",
+                // Versions < 1.3.1 has dependencies on PolySharp
+                @"Utf8StringInterpolation"
+                // Versions 2.0.0 has dependencies on Utf8StringInterpolation 1.3.0
+                @"ZLogger"
             };
 
             var excludedPackagesRegex = new Regex(@$"^{string.Join('|', excludedPackages)}$");


### PR DESCRIPTION
add zlogger and zstring

zlogger   https://www.nuget.org/packages/ZLogger
Utf8StringInterpolation  https://www.nuget.org/packages/Utf8StringInterpolation/
zstring  https://www.nuget.org/packages/ZString/

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/XXX
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


