### PR TITLE
Add Sylvan.Data.Csv

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1378,6 +1378,10 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "Sylvan.Data.Csv": {
+    "listed": true,
+    "version": "0.1.0"
+  },
   "System.Buffers": {
     "listed": true,
     "version": "4.4.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package: https://www.nuget.org/packages/Sylvan.Data.Csv
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


