### PR TITLE
Add Serilog Enrichers

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1232,13 +1232,33 @@
     "listed": true,
     "version": "2.8.0"
   },
+  "Serilog.Enrichers.AssemblyName": {
+    "listed": true,
+    "version": "1.0.6"
+  },
+  "Serilog.Enrichers.Context": {
+    "listed": true,
+    "version": "4.6.5"
+  },
   "Serilog.Enrichers.Demystifier": {
     "listed": true,
     "version": "0.9.0"
   },
+  "Serilog.Enrichers.Environment": {
+    "listed": true,
+    "version": "2.2.0"
+  },
   "Serilog.Enrichers.Memory": {
     "listed": true,
     "version": "1.0.4"
+  },
+  "Serilog.Enrichers.Process": {
+    "listed": true,
+    "version": "2.0.2"
+  },
+  "Serilog.Enrichers.Thread": {
+    "listed": true,
+    "version": "3.1.0"
   },
   "Serilog.Expressions": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Serilog
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


