### PR TITLE
Add Agones Game Server Client SDK

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -447,6 +447,10 @@
     "listed": true,
     "version": "[2.0.0,3.0.0)"
   },
+  "Google.Api.CommonProtos": {
+    "listed": true,
+    "version": "2.0.0"
+  },
   "Google.Apis": {
     "listed": true,
     "version": "1.35.0"
@@ -470,6 +474,10 @@
   "Google.Protobuf": {
     "listed": true,
     "version": "3.8.0"
+  },
+  "Grpc": {
+    "listed": true,
+    "version": "2.23.0"
   },
   "Grpc.Core": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "AgonesSDK": {
     "listed": true,
-    "version": "1.41.0"
+    "version": "1.0.2"
   },
   "Akka": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1,4 +1,8 @@
 {
+  "AgonesSDK": {
+    "listed": true,
+    "version": "1.41.0"
+  },
   "Akka": {
     "listed": true,
     "version": "1.4.1"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/AgonesSDK
> - [x] Add a link to the dependency NuGet package: https://www.nuget.org/packages/Google.Api.CommonProtos
> - [x] Add a link to the dependency NuGet package: https://www.nuget.org/packages/Grpc
> - [x] It must have non-preview versions: [1.41.0](https://www.nuget.org/packages/AgonesSDK/1.41.0) (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


