### PR TITLE
Add VitalRouter and VitalRouter.Extensions.DependencyInjection

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1652,6 +1652,10 @@
     "version": "1.0.4.1",
     "analyzer": true
   },
+  "UniTask": {
+    "listed": true,
+    "version": "2.0.13"
+  },
   "UnitsNet": {
     "listed": true,
     "version": "5.28.0"
@@ -1673,12 +1677,12 @@
     "version": "2.5.42"
   },
   "VitalRouter": {
-	  "listed": true,
-	  "version": "0.7.0"
+    "listed": true,
+    "version": "0.7.0"
   },
   "VitalRouter.Extensions.DependencyInjection": {
-	  "listed": true,
-	  "version": "0.7.1"
+    "listed": true,
+    "version": "0.7.1"
   },
   "VoltRpc": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1672,6 +1672,14 @@
     "listed": true,
     "version": "2.5.42"
   },
+  "VitalRouter": {
+	  "listed": true,
+	  "version": "0.7.0"
+  },
+  "VitalRouter.Extensions.DependencyInjection": {
+	  "listed": true,
+	  "version": "0.7.1"
+  },
   "VoltRpc": {
     "listed": true,
     "version": "1.0.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/VitalRouter, https://www.nuget.org/packages/VitalRouter.Extensions.DependencyInjection/
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


