### PR TITLE
Added HotChocolate and StrawberryShake packages.

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -537,6 +537,26 @@
       "UNITY_EDITOR"
     ]
   },
+  "HotChocolate.Language.SyntaxTree": {
+    "listed": true,
+    "version": "11.0.0"
+  },
+  "HotChocolate.Transport.Abstractions": {
+    "listed": true,
+    "version": "13.4.0"
+  },
+  "HotChocolate.Transport.Http": {
+    "listed": true,
+    "version": "13.4.0"
+  },
+  "HotChocolate.Transport.Sockets": {
+    "listed": true,
+    "version": "13.0.0"
+  },
+  "HotChocolate.Utilities": {
+    "listed": true,
+    "version": "11.0.0"
+  },
   "HtmlAgilityPack": {
     "listed": true,
     "version": "1.11.24"
@@ -1427,6 +1447,22 @@
   "Stateless": {
     "listed": true,
     "version": "4.3.0"
+  },
+  "StrawberryShake.Core": {
+    "listed": true,
+    "version": "11.1.0"
+  },
+  "StrawberryShake.Resources": {
+    "listed": true,
+    "version": "11.1.0"
+  },
+  "StrawberryShake.Transport.Http": {
+    "listed": true,
+    "version": "11.1.0"
+  },
+  "StrawberryShake.Transport.WebSockets": {
+    "listed": true,
+    "version": "11.1.0"
   },
   "StrongInject": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1561,6 +1561,10 @@
     "listed": true,
     "version": "4.5.0"
   },
+  "System.Net.Http.Json": {
+    "listed": true,
+    "version": "3.2.0"
+  },
   "System.Net.Http.WinHttpHandler": {
     "listed": true,
     "version": "4.4.0"

--- a/registry.json
+++ b/registry.json
@@ -697,7 +697,7 @@
   },
   "Microsoft.AspNetCore.WebUtilities": {
     "listed": true,
-    "version": "[2.2.0]"
+    "version": "[2.0.0,2.2.0]"
   },
   "Microsoft.Azure.Kinect.Sensor": {
     "listed": true,
@@ -979,7 +979,7 @@
   },
   "Microsoft.Net.Http.Headers": {
     "listed": true,
-    "version": "[2.2.8]"
+    "version": "[2.0.0,2.2.8]"
   },
   "Microsoft.NET.StringTools": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -697,7 +697,7 @@
   },
   "Microsoft.AspNetCore.WebUtilities": {
     "listed": true,
-    "version": "2.0.0"
+    "version": "[2.2.0]"
   },
   "Microsoft.Azure.Kinect.Sensor": {
     "listed": true,
@@ -976,6 +976,10 @@
   "Microsoft.IO.RecyclableMemoryStream": {
     "listed": true,
     "version": "1.4.0"
+  },
+  "Microsoft.Net.Http.Headers": {
+    "listed": true,
+    "version": "[2.2.8]"
   },
   "Microsoft.NET.StringTools": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -555,7 +555,7 @@
   },
   "HotChocolate.Utilities": {
     "listed": true,
-    "version": "11.0.0"
+    "version": "0.7.0"
   },
   "HtmlAgilityPack": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -695,6 +695,10 @@
     "listed": true,
     "version": "3.0.0"
   },
+  "Microsoft.AspNetCore.WebUtilities": {
+    "listed": true,
+    "version": "2.0.0"
+  },
   "Microsoft.Azure.Kinect.Sensor": {
     "listed": true,
     "version": "1.2.0"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [X] Add a link to the NuGet package: https://www.nuget.org/packages/XXX
> - [X] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [X] It must provide .NETStandard2.0 assemblies as part of its package
     _Checked on nuget.org._
> - [X] The lowest version added must be the lowest .NETStandard2.0 version available
      _Searched for oldest netstandard2.0 package on nuget.org._
> - [X] The package has been tested with the Unity editor 
> - [X] The package has been tested with a Unity standalone player
      _Running in customer projects using copied assemblies._   
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [X] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
      _All dependencies are available from this NuGet feed - tested by accessing the feed through openUPM._ 
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


