### PR TITLE
Add additional dependencies for Prims.Core

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1148,9 +1148,17 @@
     "listed": true,
     "version": "6.0.0"
   },
+  "Prism.Container.Abstractions": {
+    "listed": true,
+    "version": "9.0.88"
+  },
   "Prism.Core": {
     "listed": true,
     "version": "7.0.0.362"
+  },
+  "Prism.Events": {
+    "listed": true,
+    "version": "9.0.537"
   },
   "protobuf-net": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/XXX
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [ ] The package has been tested with the Unity editor 
> - [ ] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

fix #396 