### PR TITLE
FIx ClosedXML version range to prevent invalid RBush dependency

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -995,7 +995,7 @@
     "listed": true,
     "version": "1.0.8"
   },
-  "MiniExcel":{
+  "MiniExcel": {
     "listed": true,
     "version": "0.2.0"
   },

--- a/registry.json
+++ b/registry.json
@@ -149,7 +149,11 @@
   },
   "ClosedXML": {
     "listed": true,
-    "version": "0.92.1"
+    "version": "(0.92.1,0.102.3]"
+  },
+  "ClosedXML.Parser": {
+    "listed": true,
+    "version": "1.0.0"
   },
   "CLSS.Constants.CollectionPool": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -149,7 +149,7 @@
   },
   "ClosedXML": {
     "listed": true,
-    "version": "(0.92.1,0.102.3]"
+    "version": "[0.92.1,0.102.3]"
   },
   "ClosedXML.Parser": {
     "listed": true,


### PR DESCRIPTION
It does not target .NET Standard 2.0: https://www.nuget.org/packages/RBush