### PR TITLE
Add missing dependency

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -578,6 +578,10 @@
     "version": "1.0.0",
     "analyzer": true
   },
+  "IndexRange": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "Injecter": {
     "listed": true,
     "version": "1.0.0"


### PR DESCRIPTION
Fixes:

The package `Semver.3.0.0` has a dependency on `IndexRange` which is not in the registry. You must add this dependency to the registry.json file.