### PR TITLE
add process-x

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1737,7 +1737,7 @@
   },
   "Validation": {
     "listed": true,
-    "version": "2.5.42"さ
+    "version": "2.5.42"
   },
   "VoltRpc": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1202,7 +1202,7 @@
   },
   "ProcessX": {
     "listed": true,
-    "version": "1.5.5"
+    "version": "1.0.0"
   },
   "protobuf-net": {
     "listed": true,
@@ -1737,7 +1737,7 @@
   },
   "Validation": {
     "listed": true,
-    "version": "2.5.42"
+    "version": "2.5.42"さ
   },
   "VoltRpc": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1200,6 +1200,10 @@
     "listed": true,
     "version": "9.0.537"
   },
+  "ProcessX": {
+    "listed": true,
+    "version": "1.5.5"
+  },
   "protobuf-net": {
     "listed": true,
     "version": "2.3.6"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/ProcessX
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


