### PR TITLE
add supabase-csharp

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -469,7 +469,7 @@
   },
   "functions-csharp": {
     "listed": true,
-    "version": "1.3.1"
+    "version": "1.0.0"
   },
   "GeneticSharp": {
     "listed": true,
@@ -1022,6 +1022,10 @@
   "Microsoft.Win32.Registry": {
     "listed": true,
     "version": "4.4.0"
+  },
+  "MimeMapping": {
+    "listed": true,
+    "version": "2.0.0"
   },
   "MimeTypeMapOfficial": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -505,7 +505,7 @@
   },
   "gotrue-csharp": {
     "listed": true,
-    "version": "4.2.6"
+    "version": "2.1.4"
   },
   "GraphQL.Client": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1202,7 +1202,7 @@
   },
   "postgrest-csharp": {
     "listed": true,
-    "version": "3.4.1"
+    "version": "2.0.0"
   },
   "Prism.Container.Abstractions": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1025,7 +1025,7 @@
   },
   "MimeMapping": {
     "listed": true,
-    "version": "2.0.0"
+    "version": "1.0.1.14"
   },
   "MimeTypeMapOfficial": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -467,6 +467,10 @@
     "listed": true,
     "version": "8.2.2"
   },
+  "functions-csharp": {
+    "listed": true,
+    "version": "1.3.1"
+  },
   "GeneticSharp": {
     "listed": true,
     "version": "[2.0.0,3.0.0)"
@@ -498,6 +502,10 @@
   "Google.Protobuf": {
     "listed": true,
     "version": "3.8.0"
+  },
+  "gotrue-csharp": {
+    "listed": true,
+    "version": "4.2.6"
   },
   "GraphQL.Client": {
     "listed": true,
@@ -1188,6 +1196,10 @@
     "listed": true,
     "version": "6.0.0"
   },
+  "postgrest-csharp": {
+    "listed": true,
+    "version": "3.4.1"
+  },
   "Prism.Container.Abstractions": {
     "listed": true,
     "version": "9.0.88"
@@ -1239,6 +1251,10 @@
   "ReactiveProperty.Core": {
     "listed": true,
     "version": "7.0.0"
+  },
+  "realtime-csharp": {
+    "listed": true,
+    "version": "6.0.4"
   },
   "RestSharp": {
     "listed": true,
@@ -1492,6 +1508,18 @@
   "SunCalcNet": {
     "listed": true,
     "version": "1.1.0"
+  },
+  "supabase-core": {
+    "listed": true,
+    "version": "0.0.3"
+  },
+  "supabase-csharp": {
+    "listed": true,
+    "version": "0.15.0"
+  },
+  "supabase-storage-csharp": {
+    "listed": true,
+    "version": "1.4.0"
   },
   "Sylvan.Data.Csv": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1795,13 +1795,13 @@
     "listed": true,
     "version": "1.0.1"
   },
-  "Websocketsharp.core": {
-    "listed": true,
-    "version": "1.0.0"
-  },
   "WebSocketSharp-netstandard": {
     "listed": true,
     "version": "1.0.1"
+  },
+  "Websocketsharp.core": {
+    "listed": true,
+    "version": "1.0.0"
   },
   "XLParser": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1515,7 +1515,7 @@
   },
   "supabase-core": {
     "listed": true,
-    "version": "0.0.3"
+    "version": "0.0.1"
   },
   "supabase-csharp": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -614,6 +614,10 @@
     "listed": true,
     "version": "5.2.0"
   },
+  "JWTDecoder": {
+    "listed": true,
+    "version": "0.9.0"
+  },
   "K4os.Compression.LZ4": {
     "listed": true,
     "version": "1.0.2"
@@ -1519,7 +1523,7 @@
   },
   "supabase-csharp": {
     "listed": true,
-    "version": "0.15.0"
+    "version": "0.2.0"
   },
   "supabase-storage-csharp": {
     "listed": true,
@@ -1794,6 +1798,10 @@
   "Websocketsharp.core": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "WebSocketSharp-netstandard": {
+    "listed": true,
+    "version": "1.0.1"
   },
   "XLParser": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1527,7 +1527,7 @@
   },
   "supabase-storage-csharp": {
     "listed": true,
-    "version": "1.4.0"
+    "version": "1.0.0"
   },
   "Sylvan.Data.Csv": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1258,7 +1258,7 @@
   },
   "realtime-csharp": {
     "listed": true,
-    "version": "6.0.4"
+    "version": "2.0.0"
   },
   "RestSharp": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1517,6 +1517,10 @@
     "listed": true,
     "version": "1.1.0"
   },
+  "Supabase": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "supabase-core": {
     "listed": true,
     "version": "0.0.1"
@@ -1528,6 +1532,30 @@
   "supabase-storage-csharp": {
     "listed": true,
     "version": "1.0.0"
+  },
+  "Supabase.Core": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Supabase.Functions": {
+    "listed": true,
+    "version": "2.0.0"
+  },
+  "Supabase.Gotrue": {
+    "listed": true,
+    "version": "5.0.0"
+  },
+  "Supabase.Postgrest": {
+    "listed": true,
+    "version": "4.0.0"
+  },
+  "Supabase.Realtime": {
+    "listed": true,
+    "version": "7.0.0"
+  },
+  "Supabase.Storage": {
+    "listed": true,
+    "version": "2.0.2"
   },
   "Sylvan.Data.Csv": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1555,7 +1555,7 @@
   },
   "Supabase.Storage": {
     "listed": true,
-    "version": "2.0.2"
+    "version": "2.0.0"
   },
   "Sylvan.Data.Csv": {
     "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: 
- recommended: https://www.nuget.org/packages/Supabase/1.0.5
- obsolete: https://www.nuget.org/packages/supabase-csharp
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


