### PR TITLE
Add firestore and firestore admin

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -483,6 +483,10 @@
     "listed": true,
     "version": "2.7.0"
   },
+  "Google.Api.Gax.Grpc.GrpcCore": {
+    "listed": true,
+    "version": "3.0.0"
+  },
   "Google.Apis": {
     "listed": true,
     "version": "1.35.0"

--- a/registry.json
+++ b/registry.json
@@ -700,7 +700,7 @@
   },
   "MessagePack": {
     "listed": true,
-    "version": "1.7.0"
+    "version": "[1.7.0,3)"
   },
   "MessagePack.Annotations": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -471,6 +471,18 @@
     "listed": true,
     "version": "[2.0.0,3.0.0)"
   },
+  "Google.Api.CommonProtos": {
+    "listed": true,
+    "version": "1.7.0"
+  },
+  "Google.Api.Gax": {
+    "listed": true,
+    "version": "2.7.0"
+  },
+  "Google.Api.Gax.Grpc": {
+    "listed": true,
+    "version": "2.7.0"
+  },
   "Google.Apis": {
     "listed": true,
     "version": "1.35.0"
@@ -491,9 +503,29 @@
     "listed": true,
     "version": "1.35.1.1303"
   },
+  "Google.Cloud.Firestore": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Google.Cloud.Firestore.Admin.V1": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Google.Cloud.Firestore.V1": {
+    "listed": true,
+    "version": "1.0.0"
+  },
+  "Google.Cloud.Location": {
+    "listed": true,
+    "version": "1.0.0"
+  },
   "Google.FlatBuffers": {
     "listed": true,
     "version": "22.9.24"
+  },
+  "Google.LongRunning": {
+    "listed": true,
+    "version": "2.0.0"
   },
   "Google.Protobuf": {
     "listed": true,
@@ -522,6 +554,10 @@
   "GraphQL.Primitives": {
     "listed": true,
     "version": "2.0.0"
+  },
+  "Grpc.Auth": {
+    "listed": true,
+    "version": "1.20.0"
   },
   "Grpc.Core": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -700,11 +700,16 @@
   },
   "MessagePack": {
     "listed": true,
-    "version": "[1.7.0,3)"
+    "version": "1.7.0"
   },
   "MessagePack.Annotations": {
     "listed": true,
     "version": "2.0.323"
+  },
+  "MessagePackAnalyzer": {
+    "listed": true,
+    "version": "2.5.187",
+    "analyzer": true
   },
   "MessagePipe": {
     "listed": true,


### PR DESCRIPTION
Add firestore and firestore admin

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [ x ] Add a link to the NuGet package: https://www.nuget.org/packages/XXX
> - [ x ] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [ x ] It must provide .NETStandard2.0 assemblies as part of its package
> - [ x ] The lowest version added must be the lowest .NETStandard2.0 version available
> - [ x ] The package has been tested with the Unity editor 
> - [ ] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [ x ] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

https://www.nuget.org/packages/Google.Cloud.Firestore
https://www.nuget.org/packages/Google.Cloud.Firestore.Admin.V1

https://www.nuget.org/packages/Google.Cloud.Location/
https://www.nuget.org/packages/Google.LongRunning/
https://www.nuget.org/packages/Google.Api.Gax/
https://www.nuget.org/packages/Google.Api.Gax.Grpc/
https://www.nuget.org/packages/Google.Api.CommonProtos/
https://www.nuget.org/packages/Grpc.Auth/

I am not sure if these package was compatible with standalone player. But it was intended to used in editor mainly