### PR TITLE
GraphQL.Client.Serializer.SystemTextJson

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -553,7 +553,7 @@
   },
   "GraphQL.Client.Serializer.SystemTextJson": {
     "listed": true,
-    "version": "2.1.0"
+    "version": "3.1.9"
   },
   "GraphQL.Common": {
     "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -551,6 +551,10 @@
     "listed": true,
     "version": "3.1.9"
   },
+  "GraphQL.Client.Serializer.SystemTextJson": {
+    "listed": true,
+    "version": "3.1.9"
+  },
   "GraphQL.Common": {
     "listed": true,
     "version": "1.0.0"

--- a/registry.json
+++ b/registry.json
@@ -553,7 +553,7 @@
   },
   "GraphQL.Client.Serializer.SystemTextJson": {
     "listed": true,
-    "version": "3.1.9"
+    "version": "2.1.0"
   },
   "GraphQL.Common": {
     "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -148,7 +148,9 @@ namespace UnityNuGet.Tests
                 // Versions 2.0.0 has dependencies on Utf8StringInterpolation 1.3.0
                 @"ZLogger",
                 // Version 3.1.8 has dependency on `Panic.StringUtils` which doesn't support .netstandard2.0 or 2.1. Rest of versions are fine.
-                @"GraphQL.Client.Serializer.Newtonsoft"
+                @"GraphQL.Client.Serializer.Newtonsoft",
+                // Version 3.1.8 has dependency on `Panic.StringUtils` which doesn't support .netstandard2.0 or 2.1. Rest of versions are fine.
+                @"GraphQL.Client.Serializer.SystemTextJson"
             };
 
             var excludedPackagesRegex = new Regex(@$"^{string.Join('|', excludedPackages)}$");


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/GraphQL.Client.Serializer.SystemTextJson
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


