### PR TITLE
Allow prerelease versions

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1566,6 +1566,17 @@
         "listed": true,
         "version": "1.4.1"
     },
+    "StyleCop.Analyzers": {
+        "listed": true,
+        "version": "1.0.0",
+        "analyzer": true,
+        "includePrerelease": true
+    },
+    "StyleCop.Analyzers.Unstable": {
+        "listed": true,
+        "version": "1.1.0.47",
+        "analyzer": true
+    },
     "SunCalcNet": {
         "listed": true,
         "version": "1.1.0"

--- a/src/UnityNuGet.Tests/PlatformDefinitionTests.cs
+++ b/src/UnityNuGet.Tests/PlatformDefinitionTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;

--- a/src/UnityNuGet.Tests/RegistryCacheTests.cs
+++ b/src/UnityNuGet.Tests/RegistryCacheTests.cs
@@ -3,10 +3,11 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
 using Moq;
+using NuGet.Versioning;
 using NUnit.Framework;
 using UnityNuGet.Npm;
 
@@ -14,6 +15,17 @@ namespace UnityNuGet.Tests
 {
     public class RegistryCacheTests
     {
+        [Test]
+        [TestCase("1.0.0", "1.0.0")]
+        [TestCase("1.0.0.0", "1.0.0")]
+        [TestCase("1.0.0.1", "1.0.0-1")]
+        [TestCase("1.0.0-preview.1.24080.9", "1.0.0-preview.1.24080.9")]
+        [TestCase("1.0.0.1-preview.1.24080.9", "1.0.0-1.preview.1.24080.9")]
+        public void GetNpmVersion(string version, string expected)
+        {
+            Assert.That(RegistryCache.GetNpmVersion(NuGetVersion.Parse(version)), Is.EqualTo(expected));
+        }
+
         [Test]
         public async Task TestBuild()
         {

--- a/src/UnityNuGet.Tests/VersionRangeConverterTests.cs
+++ b/src/UnityNuGet.Tests/VersionRangeConverterTests.cs
@@ -10,7 +10,7 @@ namespace UnityNuGet.Tests
         [Test]
         public void Read_Write_Success()
         {
-            string json = @"{""ignore"":false,""listed"":false,""version"":""[1.2.3, )"",""defineConstraints"":[],""analyzer"":false}";
+            string json = @"{""ignore"":false,""listed"":false,""version"":""[1.2.3, )"",""defineConstraints"":[],""analyzer"":false,""includePrerelease"":false}";
 
             RegistryEntry registryEntry = JsonSerializer.Deserialize(json, UnityNugetJsonSerializerContext.Default.RegistryEntry)!;
 

--- a/src/UnityNuGet/RegistryEntry.cs
+++ b/src/UnityNuGet/RegistryEntry.cs
@@ -23,5 +23,8 @@ namespace UnityNuGet
 
         [JsonPropertyName("analyzer")]
         public bool Analyzer { get; set; }
+
+        [JsonPropertyName("includePrerelease")]
+        public bool IncludePrerelease { get; set; }
     }
 }


### PR DESCRIPTION
[StyleCop.Analyzers](https://www.nuget.org/packages/StyleCop.Analyzers/) has not released a stable version since 2019 and [has no intention of doing so](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3500)