### PR TITLE
Add Microsoft.Extensions.Diagnostics.HealthChecks and Microsoft.Exten…

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1033,7 +1033,7 @@
         "version": "8.0.0"
     },
     "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
-        "listed": true,
+        "listed": false,
         "version": "8.0.0"
     },
     "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {


### PR DESCRIPTION
…sions.Diagnostics.HealthChecks.Abstractions to registry.json

> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package:
    - https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks/
    - https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions/
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [ ] The package has been tested with the Unity editor 
> - [ ] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.

Add Microsoft.Extensions.Diagnostics.HealthChecks and Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions to fix error:
```
Error initializing the server:
The package `Akka.Hosting.1.5.48.1` has a dependency on `Microsoft.Extensions.Diagnostics.HealthChecks` which is not in the registry. You must add this dependency to the registry.json file.
```