### PR TITLE
Added MasterMemory and MasterMemory.Annotations

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -745,7 +745,7 @@
     },
     "MasterMemory": {
         "listed": true,
-        "version": "2.0.0"
+        "version": "3.0.1"
     },
     "MasterMemory.Annotations": {
         "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -185,6 +185,8 @@ namespace UnityNuGet.Tests
                 @"GraphQL.Client.Serializer.Newtonsoft",
                 // Version 3.1.8 has dependency on `Panic.StringUtils` which doesn't support .netstandard2.0 or 2.1. Rest of versions are fine.
                 @"GraphQL.Client.Serializer.SystemTextJson",
+                // Version 3.0.0 has a dependency on MasterMemory.SourceGenerator that no longer exists
+                @"MasterMemory",
                 // Although 2.x targets .netstandard2.0 it has an abandoned dependency (Remotion.Linq) that does not target .netstandard2.0.
                 // 3.1.0 is set because 3.0.x only targets .netstandard2.1.
                 @"Microsoft.EntityFrameworkCore.*",


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: [https://www.nuget.org/packages/MasterMemory](https://www.nuget.org/packages/MasterMemory) and [https://www.nuget.org/packages/MasterMemory.Annotations](https://www.nuget.org/packages/MasterMemory.Annotations)
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


