### PR TITLE
Allow serving on missing dependency errors

### DIFF
--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         - Registry:RegistryFilePath=/data/registry.json # Path to the file (relative or absolute) where the packages registry file will be stored, default is "registry.json".
         - Registry:RootPersistentFolder=/data/unity_packages # Path to the folder (relative or absolute) where the packages cache will be stored, default is "unity_packages".
         - Registry:UpdateInterval=00:01:00 # Packages update interval, default is "00:10:00" (10 minutes).
+        - Registry:AllowServingWithMissingDependencies=false # Set to true to ignore missing dependency errors and keep serving (friendlier for production).
         - Logging:LogLevel:Default=Information
       ports:
         - 5000:8080

--- a/src/UnityNuGet.Server.Tests/AllowServingWithMissingDependenciesTests.cs
+++ b/src/UnityNuGet.Server.Tests/AllowServingWithMissingDependenciesTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using UnityNuGet;
+using UnityNuGet.Npm;
+
+namespace UnityNuGet.Server.Tests
+{
+    public class AllowServingWithMissingDependenciesTests
+    {
+        private readonly AllowServingWithMissingDependenciesWebApplicationFactory _webApplicationFactory;
+
+        public AllowServingWithMissingDependenciesTests()
+        {
+            _webApplicationFactory = new AllowServingWithMissingDependenciesWebApplicationFactory();
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            _webApplicationFactory.Dispose();
+        }
+
+        [Test]
+        public async Task GetAll_Succeeds_WhenBuildHasErrors()
+        {
+            using HttpClient httpClient = _webApplicationFactory.CreateDefaultClient();
+
+            await WaitForInitialization(_webApplicationFactory.Services, TimeSpan.FromMinutes(2));
+
+            RegistryCacheReport registryCacheReport = _webApplicationFactory.Services.GetRequiredService<RegistryCacheReport>();
+            Assert.That(registryCacheReport.ErrorMessages.Any(), Is.True, "Expected build errors but none were reported.");
+
+            HttpResponseMessage response = await httpClient.GetAsync("/-/all");
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+
+            string responseContent = await response.Content.ReadAsStringAsync();
+            NpmPackageListAllResponse npmPackageListAllResponse = JsonSerializer.Deserialize(
+                responseContent,
+                UnityNuGetJsonSerializerContext.Default.NpmPackageListAllResponse)!;
+
+            Assert.That(npmPackageListAllResponse, Is.Not.Null);
+        }
+
+        private static async Task WaitForInitialization(IServiceProvider serviceProvider, TimeSpan timeout)
+        {
+            RegistryCacheSingleton registryCacheSingleton = serviceProvider.GetRequiredService<RegistryCacheSingleton>();
+
+            DateTime deadline = DateTime.UtcNow.Add(timeout);
+
+            while (registryCacheSingleton.Instance == null)
+            {
+                if (DateTime.UtcNow >= deadline)
+                {
+                    Assert.Fail("Timed out waiting for RegistryCache initialization.");
+                }
+
+                await Task.Delay(50);
+            }
+        }
+    }
+
+    internal class AllowServingWithMissingDependenciesWebApplicationFactory : WebApplicationFactory<Program>
+    {
+        private readonly string _rootPersistentFolder;
+        private readonly string _registryFilePath;
+
+        public AllowServingWithMissingDependenciesWebApplicationFactory()
+        {
+            _rootPersistentFolder = Path.Combine(Path.GetTempPath(), "UnityNuGet.Server.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_rootPersistentFolder);
+
+            _registryFilePath = Path.Combine(AppContext.BaseDirectory, "registry.test.missing-dep.json");
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+
+            builder.ConfigureAppConfiguration(configBuilder =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { WebHostDefaults.ServerUrlsKey, "http://localhost" },
+                    { "Registry:RegistryFilePath", _registryFilePath },
+                    { "Registry:RootPersistentFolder", _rootPersistentFolder },
+                    { "Registry:AllowServingWithMissingDependencies", "true" },
+                    { "Registry:Filter", "Serilog.Sinks.File" }
+                });
+            });
+        }
+    }
+}

--- a/src/UnityNuGet.Server.Tests/UnityNuGet.Server.Tests.csproj
+++ b/src/UnityNuGet.Server.Tests/UnityNuGet.Server.Tests.csproj
@@ -21,4 +21,10 @@
     <ProjectReference Include="..\UnityNuGet.Server\UnityNuGet.Server.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="registry.test.missing-dep.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/UnityNuGet.Server.Tests/registry.test.missing-dep.json
+++ b/src/UnityNuGet.Server.Tests/registry.test.missing-dep.json
@@ -1,0 +1,6 @@
+{
+    "Serilog.Sinks.File": {
+        "listed": true,
+        "version": "5.0.0"
+    }
+}

--- a/src/UnityNuGet.Server/appsettings.json
+++ b/src/UnityNuGet.Server/appsettings.json
@@ -10,6 +10,7 @@
         "RegistryFilePath": "registry.json",
         "RootPersistentFolder": "unity_packages",
         "UpdateInterval": "00:10:00",
+        "AllowServingWithMissingDependencies": false,
         "TargetFrameworks": [
             {
                 "Name": "netstandard2.0",

--- a/src/UnityNuGet/RegistryOptions.cs
+++ b/src/UnityNuGet/RegistryOptions.cs
@@ -35,6 +35,8 @@ namespace UnityNuGet
         [Required]
         public TimeSpan UpdateInterval { get; set; }
 
+        public bool AllowServingWithMissingDependencies { get; set; }
+
         [Required]
         [ValidateEnumeratedItems]
         public RegistryTargetFramework[]? TargetFrameworks { get; set; }


### PR DESCRIPTION
This PR lets the server continue serving instead of hanging on initialization errors caused by missing dependencies.
  This is more friendly for production use. The behavior is controlled by a flag and defaults to fail‑fast, so
  non‑production deployments behave exactly as before.
  
Details
  - Add `Registry:AllowServingWithMissingDependencies` to keep serving when build errors are only missing-dependency
  registry errors.
  - Add a server test using a minimal registry file that triggers missing dependency errors and confirms the server
  still responds.
  - Document the new flag in `examples/docker/docker-compose.yml`.

Testing
  - `dotnet test src/UnityNuGet.Server.Tests/UnityNuGet.Server.Tests.csproj`