### PR TITLE
Add curl to runtime Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN dotnet publish src/UnityNuGet.Server -a "$TARGETARCH" -c Release -o /app/src
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
+RUN apt-get update && \
+    apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /app/src/out .
 ENTRYPOINT ["dotnet", "UnityNuGet.Server.dll"]


### PR DESCRIPTION
Install curl in the runtime Docker image so health checks and diagnostics can use `/status` (and `/-/all`), since the base .NET image doesn’t include wget/curl (dotnet/dotnet-docker#2379).
