### PR TITLE
Add macOS Universal Binary runtime support

### DIFF
--- a/src/UnityNuGet/NativeLibraries.cs
+++ b/src/UnityNuGet/NativeLibraries.cs
@@ -30,9 +30,9 @@ namespace UnityNuGet
 
                 string[] system = folders[1].Split('-');
 
-                if (system.Length != 2)
+                if (system.Length < 1)
                 {
-                    logger.LogInformation($"Skipping file located in the runtime folder that does not specify platform and architecture: {file} ...");
+                    logger.LogInformation($"Skipping file located in the runtime folder that does not specify platform: {file} ...");
                     continue;
                 }
 
@@ -51,13 +51,21 @@ namespace UnityNuGet
                     continue;
                 }
 
-                UnityCpu? cpu = system[1] switch
+                UnityCpu? cpu = null;
+                if (system.Length > 1)
                 {
-                    "x86" => UnityCpu.X86,
-                    "x64" => UnityCpu.X64,
-                    "arm64" => UnityCpu.ARM64,
-                    _ => null
-                };
+                    cpu = system[1] switch
+                    {
+                        "x86" => UnityCpu.X86,
+                        "x64" => UnityCpu.X64,
+                        "arm64" => UnityCpu.ARM64,
+                        _ => null
+                    };
+                }
+                else if (os == UnityOs.OSX)
+                {
+                    cpu = UnityCpu.AnyCpu;
+                }
 
                 if (cpu is null)
                 {


### PR DESCRIPTION
## Summary

- Support `osx` (without architecture suffix) runtime identifier for native libraries
- Enable Universal Binary (FAT) packages that work on both Intel and Apple Silicon Macs
- Use `UnityCpu.AnyCpu` for osx Universal Binary native libraries

## Changes

- Modified `NativeLibraries.cs` to accept osx runtime identifier without architecture suffix
- Added test case for osx Universal Binary native libraries

## Examples of Universal Binary packages

- MongoDB.Libmongocrypt
- FlipBinding.CSharp

## Related

- https://github.com/GlitchEnzo/NuGetForUnity/pull/744

## Test plan

- [x] Run `RegistryTests` - all 457 tests passed
- [x] Verified installation via Unity Package Manager with local docker-compose (FlipBinding.CSharp) on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)