### PR TITLE
Fix zero-byte binary entries in generated UPM tarballs

### DIFF
--- a/src/UnityNuGet.Tests/RegistryCacheTests.cs
+++ b/src/UnityNuGet.Tests/RegistryCacheTests.cs
@@ -95,6 +95,7 @@ namespace UnityNuGet.Tests
             {
                 while (tarReader.GetNextEntry() is TarEntry entry)
                 {
+                    Assert.That(entry.Length, Is.GreaterThan(0), $"Entry '{entry.Name}' has zero bytes");
                     entries.Add(entry.Name);
                 }
             }

--- a/src/UnityNuGet/RegistryCache.cs
+++ b/src/UnityNuGet/RegistryCache.cs
@@ -1323,6 +1323,11 @@ namespace UnityNuGet
             filePath = filePath.Replace(@"\", "/");
             filePath = filePath.TrimStart('/');
 
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+
             var tarEntry = new PaxTarEntry(TarEntryType.RegularFile, $"package/{filePath}")
             {
                 ModificationTime = modTime,


### PR DESCRIPTION
### Problem

Binary files (DLLs, XMLs, native libs) in generated `.tgz` packages were always written as zero bytes.

### Cause

When migrating from SharpZipLib to `System.Formats.Tar` in #659, `WriteBufferToTar` changed its parameter from `byte[]` to `Stream`. Callers fill a `MemoryStream` via `CopyToAsync`, which advances `Position` to the end. `TarWriter` reads `DataStream` from its current position, so `Length - Position = 0` — nothing gets written.

The existing `TestBuild` test did not catch this because it only validates entry names, not entry sizes.

### Fixes

Reset `stream.Position = 0` in `WriteBufferToTar` before assigning `DataStream`, guarded by `CanSeek` for safety.

### Additional information

I think that packages added in tag `0.80.0` and subsequent updated versions are cached in OpenUPM.
If this is correct, you need to clear the cache.