### PR TITLE
Add BannedApiAnalyzers.Unity

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -140,6 +140,11 @@
         "listed": true,
         "version": "4.0.0"
     },
+    "BannedApiAnalyzers.Unity": {
+        "listed": true,
+        "version": "1.0.0",
+        "analyzer": true
+    },
     "Ben.Demystifier": {
         "listed": true,
         "version": "0.0.43"


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/BannedApiAnalyzers.Unity
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [ ] It must provide .NETStandard2.0 assemblies as part of its package **Analyzer only**
> - [ ] The lowest version added must be the lowest .NETStandard2.0 version available **Analyzer only**
> - [x] The package has been tested with the Unity editor 
> - [ ] The package has been tested with a Unity standalone player **Analyzer only**
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


