### PR TITLE
Update RegistryTests to support netstandard2.1 packages

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -2213,6 +2213,9 @@
     "VYaml.Core": {
         "ignore": true
     },
+    "VYaml.SourceGenerator": {
+        "ignore": true
+    },
     "VYaml.SourceGenerator.Roslyn3": {
         "ignore": true
     },

--- a/registry.json
+++ b/registry.json
@@ -2210,6 +2210,12 @@
         "listed": true,
         "version": "0.0.999"
     },
+    "VYaml.Core": {
+        "ignore": true
+    },
+    "VYaml.SourceGenerator.Roslyn3": {
+        "ignore": true
+    },
     "WebDav.Client": {
         "listed": true,
         "version": "2.3.0"

--- a/registry.json
+++ b/registry.json
@@ -1,4 +1,8 @@
 {
+    "AdvancedStringBuilder": {
+        "listed": true,
+        "version": "0.1.0"
+    },
     "AdysTech.CredentialManager": {
         "listed": true,
         "version": "2.3.0"
@@ -731,6 +735,14 @@
         "listed": true,
         "version": "1.5.0"
     },
+    "JavaScriptEngineSwitcher.Core": {
+        "listed": true,
+        "version": "3.0.0"
+    },
+    "JavaScriptEngineSwitcher.Jurassic": {
+        "listed": true,
+        "version": "3.0.0"
+    },
     "Jdenticon-net": {
         "listed": true,
         "version": "2.2.0"
@@ -742,6 +754,10 @@
     "Jurassic": {
         "listed": true,
         "version": "3.0.0"
+    },
+    "Jurassic.Unofficial": {
+        "listed": true,
+        "version": "2017.9.1"
     },
     "JWT": {
         "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -151,7 +151,7 @@
     },
     "BinaryEx": {
         "listed": true,
-        "version": "0.3.0"
+        "version": "0.1.0"
     },
     "BouncyCastle.Cryptography": {
         "listed": true,
@@ -343,7 +343,7 @@
     },
     "com.IvanMurzak.ReflectorNet": {
         "listed": true,
-        "version": "0.1.12"
+        "version": "0.1.0"
     },
     "CommandLineParser": {
         "listed": true,
@@ -359,7 +359,7 @@
     },
     "ComradeVanti.CSharpTools.Opt": {
         "listed": true,
-        "version": "1.0.2"
+        "version": "1.0.1"
     },
     "ComradeVanti.CSharpTools.Res": {
         "listed": true,
@@ -657,19 +657,19 @@
     },
     "Grpc.Net.Client": {
         "listed": true,
-        "version": "2.36.0"
+        "version": "2.23.2"
     },
     "Grpc.Net.Client.Web": {
         "listed": true,
-        "version": "2.36.0"
+        "version": "2.29.0"
     },
     "Grpc.Net.ClientFactory": {
         "listed": true,
-        "version": "2.37.0"
+        "version": "2.23.2"
     },
     "Grpc.Net.Common": {
         "listed": true,
-        "version": "2.36.0"
+        "version": "2.23.2"
     },
     "H.InputSimulator": {
         "listed": true,
@@ -680,7 +680,7 @@
     },
     "HarmonyX": {
         "listed": true,
-        "version": "2.0.2",
+        "version": "2.0.0",
         "defineConstraints": [
             "UNITY_EDITOR"
         ]
@@ -1245,7 +1245,7 @@
     },
     "Microsoft.IO.RecyclableMemoryStream": {
         "listed": true,
-        "version": "1.4.0"
+        "version": "1.3.0"
     },
     "Microsoft.NET.StringTools": {
         "listed": true,
@@ -1475,11 +1475,11 @@
     },
     "PlaceframeApiClient": {
         "listed": true,
-        "version": "0.1.3"
+        "version": "0.1.0"
     },
     "PlaceframeZedClient": {
         "listed": true,
-        "version": "0.1.3"
+        "version": "0.1.0"
     },
     "Polly": {
         "listed": true,
@@ -1551,7 +1551,7 @@
     },
     "protobuf-net.Grpc.ClientFactory": {
         "listed": true,
-        "version": "1.0.177"
+        "version": "1.0.75"
     },
     "pythonnet": {
         "listed": true,
@@ -1803,7 +1803,7 @@
     },
     "SourceCraftCommunity.SimplifiedCSharp": {
         "listed": true,
-        "version": "1.1.0"
+        "version": "1.0.0"
     },
     "SourceGear.sqlite3": {
         "listed": true,
@@ -2144,7 +2144,7 @@
     },
     "UniTask": {
         "listed": true,
-        "version": "2.0.14"
+        "version": "2.0.13"
     },
     "UnitsNet": {
         "listed": true,
@@ -2168,7 +2168,7 @@
     },
     "VideoLibrary": {
         "listed": true,
-        "version": "3.2.2"
+        "version": "3.2.0"
     },
     "VoltRpc": {
         "listed": true,
@@ -2188,11 +2188,11 @@
     },
     "VYaml": {
         "listed": true,
-        "version": "1.1.0"
+        "version": "0.0.999"
     },
     "VYaml.Annotations": {
         "listed": true,
-        "version": "0.28.0"
+        "version": "0.0.999"
     },
     "WebDav.Client": {
         "listed": true,
@@ -2212,7 +2212,7 @@
     },
     "YamlDotNet": {
         "listed": true,
-        "version": "12.0.0"
+        "version": "9.1.4"
     },
     "Zirou.Tomlyn.Extensions.Configuration": {
         "listed": true,
@@ -2220,7 +2220,7 @@
     },
     "ZLinq": {
         "listed": true,
-        "version": "0.5.0"
+        "version": "0.1.0"
     },
     "ZLinq.DropInGenerator": {
         "listed": true,
@@ -2233,7 +2233,7 @@
     },
     "ZstdSharp.Port": {
         "listed": true,
-        "version": "0.5.0"
+        "version": "0.1.0"
     },
     "ZString": {
         "listed": true,

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -234,6 +234,10 @@ namespace UnityNuGet.Tests
                 @"XLParser",
                 // Versions < 1.3.1 has dependencies on PolySharp
                 @"Utf8StringInterpolation",
+                // VYaml.Core is deprecated and no longer available on NuGet.org.
+                @"VYaml.Core",
+                // VYaml.SourceGenerator.Roslyn is deprecated and no longer available on NuGet.org.
+                @"VYaml.SourceGenerator.Roslyn3",
                 // Versions 2.0.0 has dependencies on Utf8StringInterpolation 1.3.0
                 @"ZLogger"
             ];

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -234,10 +234,8 @@ namespace UnityNuGet.Tests
                 @"XLParser",
                 // Versions < 1.3.1 has dependencies on PolySharp
                 @"Utf8StringInterpolation",
-                // VYaml.Core is deprecated and no longer available on NuGet.org.
-                @"VYaml.Core",
-                // VYaml.SourceGenerator.Roslyn is deprecated and no longer available on NuGet.org.
-                @"VYaml.SourceGenerator.Roslyn3",
+                // VYaml depends on VYaml.Core and VYaml.SourceGenerator.Roslyn which are no longer available on NuGet.org.
+                @"VYaml",
                 // Versions 2.0.0 has dependencies on Utf8StringInterpolation 1.3.0
                 @"ZLogger"
             ];

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -173,7 +173,7 @@ namespace UnityNuGet.Tests
             SourceRepository repository = Repository.Factory.GetCoreV3("https://api.nuget.org/v3/index.json");
             PackageMetadataResource resource = await repository.GetResourceAsync<PackageMetadataResource>();
 
-            RegistryTargetFramework[] nuGetFrameworks = [new() { Framework = CommonFrameworks.NetStandard20 }];
+            RegistryTargetFramework[] nuGetFrameworks = [new() { Framework = CommonFrameworks.NetStandard20 }, new() { Framework = CommonFrameworks.NetStandard21 }];
 
             string[] excludedPackages = [
                 // Versions 1.4.23 - 1.4.25 depend on a package that no longer exists: LightningDB.Vendored.Akka

--- a/src/UnityNuGet.Tests/RegistryTests.cs
+++ b/src/UnityNuGet.Tests/RegistryTests.cs
@@ -234,7 +234,7 @@ namespace UnityNuGet.Tests
                 @"XLParser",
                 // Versions < 1.3.1 has dependencies on PolySharp
                 @"Utf8StringInterpolation",
-                // VYaml depends on VYaml.Core and VYaml.SourceGenerator.Roslyn which are no longer available on NuGet.org.
+                // VYaml from 0.1.0 to 0.21.0 depends on VYaml.Core and VYaml.SourceGenerator.Roslyn which are no longer available on NuGet.org.
                 @"VYaml",
                 // Versions 2.0.0 has dependencies on Utf8StringInterpolation 1.3.0
                 @"ZLogger"


### PR DESCRIPTION
Fix https://github.com/bdovaz/UnityNuGet/issues/705

Test with a streamlined [`registry.json`](https://gist.github.com/laicasaane/acbbadec54a564642bf38c220c6e31bc):
- [x] Pass all test cases
- [x] Include `DryDB`
- [x] Include `MemoryPack`
