### PR TITLE
Added Redis.OM 0.1.0

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1482,6 +1482,10 @@
         "listed": true,
         "version": "1.2.0"
     },
+    "Pipelines.Sockets.Unofficial": {
+        "listed": true,
+        "version": "1.0.0"
+    },
     "PlaceframeApiClient": {
         "listed": true,
         "version": "0.1.3"
@@ -1872,7 +1876,7 @@
     },
     "StackExchange.Redis": {
         "listed": true,
-        "version": "2.7.17"
+        "version": "2.0.495"
     },
     "Stateless": {
         "listed": true,
@@ -2185,7 +2189,7 @@
     },
     "Ulid": {
         "listed": true,
-        "version": "1.2.6"
+        "version": "0.1.0"
     },
     "Validation": {
         "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1600,7 +1600,7 @@
     },
     "Redis.OM": {
         "listed": true,
-        "version": "1.3.0"
+        "version": "0.1.0"
     },
     "RestSharp": {
         "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -2170,6 +2170,10 @@
         "listed": true,
         "version": "1.4.0"
     },
+    "Ulid": {
+        "listed": true,
+        "version": "0.1.0"
+    },
     "UniRxAnalyzer": {
         "listed": true,
         "version": "1.0.4.1",
@@ -2190,10 +2194,6 @@
     "UnitsNet.Serialization.JsonNet": {
         "listed": true,
         "version": "5.28.0"
-    },
-    "Ulid": {
-        "listed": true,
-        "version": "0.1.0"
     },
     "Utf8StringInterpolation": {
         "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1606,6 +1606,10 @@
         "listed": true,
         "version": "0.1.0"
     },
+    "RESPite": {
+        "listed": true,
+        "version": "3.0.0"
+    },
     "RestSharp": {
         "listed": true,
         "version": "106.0.0"

--- a/registry.json
+++ b/registry.json
@@ -1598,6 +1598,10 @@
         "listed": true,
         "version": "7.0.0"
     },
+    "Redis.OM": {
+        "listed": true,
+        "version": "1.3.0"
+    },
     "RestSharp": {
         "listed": true,
         "version": "106.0.0"
@@ -1865,6 +1869,10 @@
     "SshNet.Security.Cryptography": {
         "listed": true,
         "version": "1.3.0"
+    },
+    "StackExchange.Redis": {
+        "listed": true,
+        "version": "2.7.17"
     },
     "Stateless": {
         "listed": true,
@@ -2174,6 +2182,10 @@
     "Utf8StringInterpolation": {
         "listed": true,
         "version": "1.3.1"
+    },
+    "Ulid": {
+        "listed": true,
+        "version": "1.2.6"
     },
     "Validation": {
         "listed": true,

--- a/registry.json
+++ b/registry.json
@@ -1950,6 +1950,10 @@
         "listed": true,
         "version": "4.5.0"
     },
+    "System.Diagnostics.PerformanceCounter": {
+        "listed": true,
+        "version": "4.5.0"
+    },
     "System.Drawing.Common": {
         "listed": true,
         "version": "4.5.0"
@@ -2183,13 +2187,13 @@
         "listed": true,
         "version": "5.28.0"
     },
-    "Utf8StringInterpolation": {
-        "listed": true,
-        "version": "1.3.1"
-    },
     "Ulid": {
         "listed": true,
         "version": "0.1.0"
+    },
+    "Utf8StringInterpolation": {
+        "listed": true,
+        "version": "1.3.1"
     },
     "Validation": {
         "listed": true,


### PR DESCRIPTION
> The NuGet package needs to respect a few constraints in order to be listed in the curated list:
> - [x] Add a link to the NuGet package: https://www.nuget.org/packages/Redis.OM
> - [x] It must have non-preview versions (e.g 1.0.0 but not 1.0.0-preview.1)
> - [x] It must provide .NETStandard2.0 assemblies as part of its package
> - [x] The lowest version added must be the lowest .NETStandard2.0 version available
> - [x] The package has been tested with the Unity editor 
> - [x] The package has been tested with a Unity standalone player
>   - if the package is not compatible with standalone player, please add a comment to a Known issues section to the top level readme.md
> - [x] All package dependencies with .NETStandard 2.0 target must be added to the PR (respecting the same rules above)
>   - Note that if a future version of the package adds a new dependency, this dependency will have to be added manually as well
> 
> Note: The server will be updated only when a new version tag is pushed on the main branch, not necessarily after merging this pull-request.


